### PR TITLE
Reorderable exercises in routines and workouts

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -200,4 +200,7 @@ dependencies {
 
     // Load images asynchronously
     implementation(libs.coil)
+
+    // Reorder items in edit workout/routine lists
+    implementation(libs.reorderable)
 }

--- a/app/lint-baseline.xml
+++ b/app/lint-baseline.xml
@@ -187,13 +187,137 @@
 
     <issue
         id="AndroidGradlePluginVersion"
-        message="A newer version of Gradle than 9.3.0 is available: 9.3.1"
-        errorLine1="distributionUrl=https\://services.gradle.org/distributions/gradle-9.3.0-bin.zip"
+        errorLine1="distributionUrl=https\://services.gradle.org/distributions/gradle-9.3.1-bin.zip"
+        message="A newer version of Gradle than 9.3.1 is available: 9.4.1"
         errorLine2="                ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="$HOME/Documents/Programmazione/LibreFit/LibreFit/gradle/wrapper/gradle-wrapper.properties"
             line="10"
             column="17"/>
+    </issue>
+
+    <issue errorLine1="agp = &quot;9.1.0&quot;"
+        errorLine2="      ~~~~~~~"
+        id="AndroidGradlePluginVersion" message="A newer version of com.android.application than 9.1.0 is available: 9.2.0. (There is also a newer version of 9.1.𝑥 available, if upgrading to 9.2.0 is difficult: 9.1.1)">
+        <location column="7"
+            file="$HOME/Documents/Programmazione/LibreFit/LibreFit/gradle/libs.versions.toml" line="2" />
+    </issue>
+
+    <issue errorLine1="datastore = &quot;1.2.0&quot;"
+        errorLine2="            ~~~~~~~"
+        id="GradleDependency" message="A newer version of androidx.datastore:datastore-core-android than 1.2.0 is available: 1.2.1">
+        <location column="13"
+            file="$HOME/Documents/Programmazione/LibreFit/LibreFit/gradle/libs.versions.toml" line="3" />
+    </issue>
+
+    <issue errorLine1="datastore = &quot;1.2.0&quot;"
+        errorLine2="            ~~~~~~~"
+        id="GradleDependency" message="A newer version of androidx.datastore:datastore-preferences than 1.2.0 is available: 1.2.1">
+        <location column="13"
+            file="$HOME/Documents/Programmazione/LibreFit/LibreFit/gradle/libs.versions.toml" line="3" />
+    </issue>
+
+    <issue errorLine1="composeBom = &quot;2026.02.01&quot;"
+        errorLine2="             ~~~~~~~~~~~~"
+        id="GradleDependency" message="A newer version of androidx.compose:compose-bom-alpha than 2026.02.01 is available: 2026.04.00">
+        <location column="14"
+            file="$HOME/Documents/Programmazione/LibreFit/LibreFit/gradle/libs.versions.toml" line="7" />
+    </issue>
+
+    <issue errorLine1="material = &quot;1.14.0-alpha09&quot;"
+        errorLine2="           ~~~~~~~~~~~~~~~~"
+        id="GradleDependency" message="A newer version of com.google.android.material:material than 1.14.0-alpha09 is available: 1.14.0-beta01">
+        <location column="12"
+            file="$HOME/Documents/Programmazione/LibreFit/LibreFit/gradle/libs.versions.toml" line="24" />
+    </issue>
+
+    <issue errorLine1="androidx-core-ktx = { group = &quot;androidx.core&quot;, name = &quot;core-ktx&quot;, version = &quot;1.17.0&quot; }"
+        errorLine2="                                                                            ~~~~~~~~"
+        id="GradleDependency"
+        message="A newer version of androidx.core:core-ktx than 1.17.0 is available: 1.18.0">
+        <location column="77"
+            file="$HOME/Documents/Programmazione/LibreFit/LibreFit/gradle/libs.versions.toml" line="29" />
+    </issue>
+
+    <issue errorLine1="androidx-activity-compose = { group = &quot;androidx.activity&quot;, name = &quot;activity-compose&quot;, version = &quot;1.12.4&quot; }"
+        errorLine2="                                                                                                ~~~~~~~~"
+        id="GradleDependency"
+        message="A newer version of androidx.activity:activity-compose than 1.12.4 is available: 1.13.0">
+        <location column="97"
+            file="$HOME/Documents/Programmazione/LibreFit/LibreFit/gradle/libs.versions.toml" line="38" />
+    </issue>
+
+    <issue errorLine1="kotlin = &quot;2.3.10&quot;"
+        errorLine2="         ~~~~~~~~"
+        id="NewerVersionAvailable" message="A newer version of org.jetbrains.kotlin.plugin.compose than 2.3.10 is available: 2.3.20">
+        <location column="10"
+            file="$HOME/Documents/Programmazione/LibreFit/LibreFit/gradle/libs.versions.toml" line="4" />
+    </issue>
+
+    <issue errorLine1="kotlin = &quot;2.3.10&quot;"
+        errorLine2="         ~~~~~~~~"
+        id="NewerVersionAvailable" message="A newer version of org.jetbrains.kotlin.plugin.serialization than 2.3.10 is available: 2.3.20">
+        <location column="10"
+            file="$HOME/Documents/Programmazione/LibreFit/LibreFit/gradle/libs.versions.toml" line="4" />
+    </issue>
+
+    <issue errorLine1="composeM3 = &quot;3.0.2&quot;"
+        errorLine2="            ~~~~~~~"
+        id="NewerVersionAvailable" message="A newer version of com.patrykandpatrick.vico:compose-m3 than 3.0.2 is available: 3.1.0">
+        <location column="13"
+            file="$HOME/Documents/Programmazione/LibreFit/LibreFit/gradle/libs.versions.toml" line="14" />
+    </issue>
+
+    <issue errorLine1="hiltAndroid = &quot;2.59.1&quot;"
+        errorLine2="              ~~~~~~~~"
+        id="NewerVersionAvailable" message="A newer version of com.google.dagger.hilt.android than 2.59.1 is available: 2.59.2">
+        <location column="15"
+            file="$HOME/Documents/Programmazione/LibreFit/LibreFit/gradle/libs.versions.toml" line="15" />
+    </issue>
+
+    <issue errorLine1="hiltAndroid = &quot;2.59.1&quot;"
+        errorLine2="              ~~~~~~~~"
+        id="NewerVersionAvailable" message="A newer version of com.google.dagger:hilt-android than 2.59.1 is available: 2.59.2">
+        <location column="15"
+            file="$HOME/Documents/Programmazione/LibreFit/LibreFit/gradle/libs.versions.toml" line="15" />
+    </issue>
+
+    <issue errorLine1="hiltAndroid = &quot;2.59.1&quot;"
+        errorLine2="              ~~~~~~~~"
+        id="NewerVersionAvailable" message="A newer version of com.google.dagger:hilt-android-compiler than 2.59.1 is available: 2.59.2">
+        <location column="15"
+            file="$HOME/Documents/Programmazione/LibreFit/LibreFit/gradle/libs.versions.toml" line="15" />
+    </issue>
+
+    <issue errorLine1="aboutLibraries = &quot;14.0.0-b02&quot;"
+        errorLine2="                 ~~~~~~~~~~~~"
+        id="NewerVersionAvailable"
+        message="A newer version of com.mikepenz.aboutlibraries.plugin.android than 14.0.0-b02 is available: 14.0.1">
+        <location column="18"
+            file="$HOME/Documents/Programmazione/LibreFit/LibreFit/gradle/libs.versions.toml" line="17" />
+    </issue>
+
+    <issue errorLine1="aboutlibrariesComposeM3 = &quot;13.2.1&quot;"
+        errorLine2="                          ~~~~~~~~"
+        id="NewerVersionAvailable"
+        message="A newer version of com.mikepenz:aboutlibraries-compose-m3 than 13.2.1 is available: 14.0.1">
+        <location column="27"
+            file="$HOME/Documents/Programmazione/LibreFit/LibreFit/gradle/libs.versions.toml" line="18" />
+    </issue>
+
+    <issue errorLine1="reorderable = &quot;3.0.0&quot;"
+        errorLine2="              ~~~~~~~"
+        id="NewerVersionAvailable" message="A newer version of sh.calvin.reorderable:reorderable than 3.0.0 is available: 3.1.0">
+        <location column="15"
+            file="$HOME/Documents/Programmazione/LibreFit/LibreFit/gradle/libs.versions.toml" line="26" />
+    </issue>
+
+    <issue errorLine1="kotlinx-serialization-json = { module = &quot;org.jetbrains.kotlinx:kotlinx-serialization-json&quot;, version = &quot;1.10.0&quot; }"
+        errorLine2="                                                                                                      ~~~~~~~~"
+        id="NewerVersionAvailable"
+        message="A newer version of org.jetbrains.kotlinx:kotlinx-serialization-json than 1.10.0 is available: 1.11.0">
+        <location column="103"
+            file="$HOME/Documents/Programmazione/LibreFit/LibreFit/gradle/libs.versions.toml" line="48" />
     </issue>
 
     <issue
@@ -232,7 +356,7 @@
     <issue
         id="RestrictedApi"
         message="RoomOpenDelegate can only be accessed from within the same library group prefix (referenced groupId=`androidx.room` with prefix androidx from groupId=`LibreFit`)"
-        errorLine1="    val _openDelegate: RoomOpenDelegate = object : RoomOpenDelegate(2, &quot;75cbdfac369ec3079afb5b5e827c56cd&quot;, &quot;c326d28156e5be12663a53d56096f0f4&quot;) {"
+        errorLine1="    val _openDelegate: RoomOpenDelegate = object : RoomOpenDelegate(3, &quot;8e973c578ef7f482bf8261f8db8abc6d&quot;, &quot;70f9af06f493ed95ae1917735c272df9&quot;) {"
         errorLine2="                       ~~~~~~~~~~~~~~~~">
         <location
             file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt"
@@ -243,7 +367,7 @@
     <issue
         id="RestrictedApi"
         message="RoomOpenDelegate can only be called from within the same library group prefix (referenced groupId=`androidx.room` with prefix androidx from groupId=`LibreFit`)"
-        errorLine1="    val _openDelegate: RoomOpenDelegate = object : RoomOpenDelegate(2, &quot;75cbdfac369ec3079afb5b5e827c56cd&quot;, &quot;c326d28156e5be12663a53d56096f0f4&quot;) {"
+        errorLine1="    val _openDelegate: RoomOpenDelegate = object : RoomOpenDelegate(3, &quot;8e973c578ef7f482bf8261f8db8abc6d&quot;, &quot;70f9af06f493ed95ae1917735c272df9&quot;) {"
         errorLine2="                                          ^">
         <location
             file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt"
@@ -254,7 +378,7 @@
     <issue
         id="RestrictedApi"
         message="RoomOpenDelegate can only be called from within the same library group prefix (referenced groupId=`androidx.room` with prefix androidx from groupId=`LibreFit`)"
-        errorLine1="    val _openDelegate: RoomOpenDelegate = object : RoomOpenDelegate(2, &quot;75cbdfac369ec3079afb5b5e827c56cd&quot;, &quot;c326d28156e5be12663a53d56096f0f4&quot;) {"
+        errorLine1="    val _openDelegate: RoomOpenDelegate = object : RoomOpenDelegate(3, &quot;8e973c578ef7f482bf8261f8db8abc6d&quot;, &quot;70f9af06f493ed95ae1917735c272df9&quot;) {"
         errorLine2="                                                   ~~~~~~~~~~~~~~~~">
         <location
             file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt"
@@ -265,7 +389,7 @@
     <issue
         id="RestrictedApi"
         message="RoomOpenDelegate can only be called from within the same library group prefix (referenced groupId=`androidx.room` with prefix androidx from groupId=`LibreFit`)"
-        errorLine1="    val _openDelegate: RoomOpenDelegate = object : RoomOpenDelegate(2, &quot;75cbdfac369ec3079afb5b5e827c56cd&quot;, &quot;c326d28156e5be12663a53d56096f0f4&quot;) {"
+        errorLine1="    val _openDelegate: RoomOpenDelegate = object : RoomOpenDelegate(3, &quot;8e973c578ef7f482bf8261f8db8abc6d&quot;, &quot;70f9af06f493ed95ae1917735c272df9&quot;) {"
         errorLine2="                                                                       ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt"
@@ -276,7 +400,7 @@
     <issue
         id="RestrictedApi"
         message="RoomOpenDelegate can only be called from within the same library group prefix (referenced groupId=`androidx.room` with prefix androidx from groupId=`LibreFit`)"
-        errorLine1="    val _openDelegate: RoomOpenDelegate = object : RoomOpenDelegate(2, &quot;75cbdfac369ec3079afb5b5e827c56cd&quot;, &quot;c326d28156e5be12663a53d56096f0f4&quot;) {"
+        errorLine1="    val _openDelegate: RoomOpenDelegate = object : RoomOpenDelegate(3, &quot;8e973c578ef7f482bf8261f8db8abc6d&quot;, &quot;70f9af06f493ed95ae1917735c272df9&quot;) {"
         errorLine2="                                                                       ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt"
@@ -287,7 +411,7 @@
     <issue
         id="RestrictedApi"
         message="RoomOpenDelegate can only be called from within the same library group prefix (referenced groupId=`androidx.room` with prefix androidx from groupId=`LibreFit`)"
-        errorLine1="    val _openDelegate: RoomOpenDelegate = object : RoomOpenDelegate(2, &quot;75cbdfac369ec3079afb5b5e827c56cd&quot;, &quot;c326d28156e5be12663a53d56096f0f4&quot;) {"
+        errorLine1="    val _openDelegate: RoomOpenDelegate = object : RoomOpenDelegate(3, &quot;8e973c578ef7f482bf8261f8db8abc6d&quot;, &quot;70f9af06f493ed95ae1917735c272df9&quot;) {"
         errorLine2="                                                                                                           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt"
@@ -298,7 +422,7 @@
     <issue
         id="RestrictedApi"
         message="RoomOpenDelegate can only be called from within the same library group prefix (referenced groupId=`androidx.room` with prefix androidx from groupId=`LibreFit`)"
-        errorLine1="    val _openDelegate: RoomOpenDelegate = object : RoomOpenDelegate(2, &quot;75cbdfac369ec3079afb5b5e827c56cd&quot;, &quot;c326d28156e5be12663a53d56096f0f4&quot;) {"
+        errorLine1="    val _openDelegate: RoomOpenDelegate = object : RoomOpenDelegate(3, &quot;8e973c578ef7f482bf8261f8db8abc6d&quot;, &quot;70f9af06f493ed95ae1917735c272df9&quot;) {"
         errorLine2="                                                                                                           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt"
@@ -323,8 +447,7 @@
         errorLine1="      public override fun dropAllTables(connection: SQLiteConnection) {"
         errorLine2="                          ~~~~~~~~~~~~~">
         <location
-            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt"
-            line="62"
+            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt" line="64"
             column="27"/>
     </issue>
 
@@ -334,8 +457,7 @@
         errorLine1="      public override fun onCreate(connection: SQLiteConnection) {"
         errorLine2="                          ~~~~~~~~">
         <location
-            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt"
-            line="70"
+            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt" line="72"
             column="27"/>
     </issue>
 
@@ -345,8 +467,7 @@
         errorLine1="      public override fun onOpen(connection: SQLiteConnection) {"
         errorLine2="                          ~~~~~~">
         <location
-            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt"
-            line="73"
+            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt" line="75"
             column="27"/>
     </issue>
 
@@ -356,8 +477,7 @@
         errorLine1="        internalInitInvalidationTracker(connection)"
         errorLine2="        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
-            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt"
-            line="75"
+            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt" line="77"
             column="9"/>
     </issue>
 
@@ -367,8 +487,7 @@
         errorLine1="      public override fun onPreMigrate(connection: SQLiteConnection) {"
         errorLine2="                          ~~~~~~~~~~~~">
         <location
-            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt"
-            line="78"
+            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt" line="80"
             column="27"/>
     </issue>
 
@@ -378,8 +497,7 @@
         errorLine1="        dropFtsSyncTriggers(connection)"
         errorLine2="        ~~~~~~~~~~~~~~~~~~~">
         <location
-            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt"
-            line="79"
+            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt" line="81"
             column="9"/>
     </issue>
 
@@ -389,8 +507,7 @@
         errorLine1="      public override fun onPostMigrate(connection: SQLiteConnection) {"
         errorLine2="                          ~~~~~~~~~~~~~">
         <location
-            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt"
-            line="82"
+            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt" line="84"
             column="27"/>
     </issue>
 
@@ -400,8 +517,7 @@
         errorLine1="      public override fun onValidateSchema(connection: SQLiteConnection): RoomOpenDelegate.ValidationResult {"
         errorLine2="                          ~~~~~~~~~~~~~~~~">
         <location
-            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt"
-            line="85"
+            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt" line="87"
             column="27"/>
     </issue>
 
@@ -411,8 +527,7 @@
         errorLine1="      public override fun onValidateSchema(connection: SQLiteConnection): RoomOpenDelegate.ValidationResult {"
         errorLine2="                                                                          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
-            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt"
-            line="85"
+            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt" line="87"
             column="75"/>
     </issue>
 
@@ -422,8 +537,7 @@
         errorLine1="        val _columnsWorkouts: MutableMap&lt;String, TableInfo.Column> = mutableMapOf()"
         errorLine2="                                                 ~~~~~~~~~~~~~~~~">
         <location
-            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt"
-            line="86"
+            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt" line="88"
             column="50"/>
     </issue>
 
@@ -433,8 +547,7 @@
         errorLine1="        _columnsWorkouts.put(&quot;id&quot;, TableInfo.Column(&quot;id&quot;, &quot;INTEGER&quot;, true, 1, null, TableInfo.CREATED_FROM_ENTITY))"
         errorLine2="                                             ~~~~~~">
         <location
-            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt"
-            line="87"
+            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt" line="89"
             column="46"/>
     </issue>
 
@@ -444,8 +557,7 @@
         errorLine1="        _columnsWorkouts.put(&quot;id&quot;, TableInfo.Column(&quot;id&quot;, &quot;INTEGER&quot;, true, 1, null, TableInfo.CREATED_FROM_ENTITY))"
         errorLine2="                                                    ~~~~">
         <location
-            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt"
-            line="87"
+            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt" line="89"
             column="53"/>
     </issue>
 
@@ -455,8 +567,7 @@
         errorLine1="        _columnsWorkouts.put(&quot;id&quot;, TableInfo.Column(&quot;id&quot;, &quot;INTEGER&quot;, true, 1, null, TableInfo.CREATED_FROM_ENTITY))"
         errorLine2="                                                          ~~~~~~~~~">
         <location
-            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt"
-            line="87"
+            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt" line="89"
             column="59"/>
     </issue>
 
@@ -466,8 +577,7 @@
         errorLine1="        _columnsWorkouts.put(&quot;id&quot;, TableInfo.Column(&quot;id&quot;, &quot;INTEGER&quot;, true, 1, null, TableInfo.CREATED_FROM_ENTITY))"
         errorLine2="                                                                              ~~~~">
         <location
-            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt"
-            line="87"
+            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt" line="89"
             column="79"/>
     </issue>
 
@@ -477,8 +587,7 @@
         errorLine1="        _columnsWorkouts.put(&quot;id&quot;, TableInfo.Column(&quot;id&quot;, &quot;INTEGER&quot;, true, 1, null, TableInfo.CREATED_FROM_ENTITY))"
         errorLine2="                                                                                              ~~~~~~~~~~~~~~~~~~~">
         <location
-            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt"
-            line="87"
+            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt" line="89"
             column="95"/>
     </issue>
 
@@ -488,8 +597,7 @@
         errorLine1="        _columnsWorkouts.put(&quot;routineId&quot;, TableInfo.Column(&quot;routineId&quot;, &quot;INTEGER&quot;, true, 0, null, TableInfo.CREATED_FROM_ENTITY))"
         errorLine2="                                                    ~~~~~~">
         <location
-            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt"
-            line="88"
+            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt" line="90"
             column="53"/>
     </issue>
 
@@ -499,8 +607,7 @@
         errorLine1="        _columnsWorkouts.put(&quot;routineId&quot;, TableInfo.Column(&quot;routineId&quot;, &quot;INTEGER&quot;, true, 0, null, TableInfo.CREATED_FROM_ENTITY))"
         errorLine2="                                                           ~~~~~~~~~~~">
         <location
-            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt"
-            line="88"
+            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt" line="90"
             column="60"/>
     </issue>
 
@@ -510,8 +617,7 @@
         errorLine1="        _columnsWorkouts.put(&quot;routineId&quot;, TableInfo.Column(&quot;routineId&quot;, &quot;INTEGER&quot;, true, 0, null, TableInfo.CREATED_FROM_ENTITY))"
         errorLine2="                                                                        ~~~~~~~~~">
         <location
-            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt"
-            line="88"
+            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt" line="90"
             column="73"/>
     </issue>
 
@@ -521,8 +627,7 @@
         errorLine1="        _columnsWorkouts.put(&quot;routineId&quot;, TableInfo.Column(&quot;routineId&quot;, &quot;INTEGER&quot;, true, 0, null, TableInfo.CREATED_FROM_ENTITY))"
         errorLine2="                                                                                            ~~~~">
         <location
-            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt"
-            line="88"
+            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt" line="90"
             column="93"/>
     </issue>
 
@@ -532,8 +637,7 @@
         errorLine1="        _columnsWorkouts.put(&quot;routineId&quot;, TableInfo.Column(&quot;routineId&quot;, &quot;INTEGER&quot;, true, 0, null, TableInfo.CREATED_FROM_ENTITY))"
         errorLine2="                                                                                                            ~~~~~~~~~~~~~~~~~~~">
         <location
-            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt"
-            line="88"
+            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt" line="90"
             column="109"/>
     </issue>
 
@@ -543,8 +647,7 @@
         errorLine1="        _columnsWorkouts.put(&quot;notes&quot;, TableInfo.Column(&quot;notes&quot;, &quot;TEXT&quot;, true, 0, null, TableInfo.CREATED_FROM_ENTITY))"
         errorLine2="                                                ~~~~~~">
         <location
-            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt"
-            line="89"
+            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt" line="91"
             column="49"/>
     </issue>
 
@@ -554,8 +657,7 @@
         errorLine1="        _columnsWorkouts.put(&quot;notes&quot;, TableInfo.Column(&quot;notes&quot;, &quot;TEXT&quot;, true, 0, null, TableInfo.CREATED_FROM_ENTITY))"
         errorLine2="                                                       ~~~~~~~">
         <location
-            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt"
-            line="89"
+            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt" line="91"
             column="56"/>
     </issue>
 
@@ -565,8 +667,7 @@
         errorLine1="        _columnsWorkouts.put(&quot;notes&quot;, TableInfo.Column(&quot;notes&quot;, &quot;TEXT&quot;, true, 0, null, TableInfo.CREATED_FROM_ENTITY))"
         errorLine2="                                                                ~~~~~~">
         <location
-            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt"
-            line="89"
+            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt" line="91"
             column="65"/>
     </issue>
 
@@ -576,8 +677,7 @@
         errorLine1="        _columnsWorkouts.put(&quot;notes&quot;, TableInfo.Column(&quot;notes&quot;, &quot;TEXT&quot;, true, 0, null, TableInfo.CREATED_FROM_ENTITY))"
         errorLine2="                                                                                 ~~~~">
         <location
-            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt"
-            line="89"
+            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt" line="91"
             column="82"/>
     </issue>
 
@@ -587,8 +687,7 @@
         errorLine1="        _columnsWorkouts.put(&quot;notes&quot;, TableInfo.Column(&quot;notes&quot;, &quot;TEXT&quot;, true, 0, null, TableInfo.CREATED_FROM_ENTITY))"
         errorLine2="                                                                                                 ~~~~~~~~~~~~~~~~~~~">
         <location
-            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt"
-            line="89"
+            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt" line="91"
             column="98"/>
     </issue>
 
@@ -598,8 +697,7 @@
         errorLine1="        _columnsWorkouts.put(&quot;title&quot;, TableInfo.Column(&quot;title&quot;, &quot;TEXT&quot;, true, 0, null, TableInfo.CREATED_FROM_ENTITY))"
         errorLine2="                                                ~~~~~~">
         <location
-            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt"
-            line="90"
+            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt" line="92"
             column="49"/>
     </issue>
 
@@ -609,8 +707,7 @@
         errorLine1="        _columnsWorkouts.put(&quot;title&quot;, TableInfo.Column(&quot;title&quot;, &quot;TEXT&quot;, true, 0, null, TableInfo.CREATED_FROM_ENTITY))"
         errorLine2="                                                       ~~~~~~~">
         <location
-            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt"
-            line="90"
+            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt" line="92"
             column="56"/>
     </issue>
 
@@ -620,8 +717,7 @@
         errorLine1="        _columnsWorkouts.put(&quot;title&quot;, TableInfo.Column(&quot;title&quot;, &quot;TEXT&quot;, true, 0, null, TableInfo.CREATED_FROM_ENTITY))"
         errorLine2="                                                                ~~~~~~">
         <location
-            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt"
-            line="90"
+            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt" line="92"
             column="65"/>
     </issue>
 
@@ -631,8 +727,7 @@
         errorLine1="        _columnsWorkouts.put(&quot;title&quot;, TableInfo.Column(&quot;title&quot;, &quot;TEXT&quot;, true, 0, null, TableInfo.CREATED_FROM_ENTITY))"
         errorLine2="                                                                                 ~~~~">
         <location
-            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt"
-            line="90"
+            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt" line="92"
             column="82"/>
     </issue>
 
@@ -642,8 +737,7 @@
         errorLine1="        _columnsWorkouts.put(&quot;title&quot;, TableInfo.Column(&quot;title&quot;, &quot;TEXT&quot;, true, 0, null, TableInfo.CREATED_FROM_ENTITY))"
         errorLine2="                                                                                                 ~~~~~~~~~~~~~~~~~~~">
         <location
-            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt"
-            line="90"
+            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt" line="92"
             column="98"/>
     </issue>
 
@@ -653,8 +747,7 @@
         errorLine1="        _columnsWorkouts.put(&quot;state&quot;, TableInfo.Column(&quot;state&quot;, &quot;TEXT&quot;, true, 0, null, TableInfo.CREATED_FROM_ENTITY))"
         errorLine2="                                                ~~~~~~">
         <location
-            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt"
-            line="91"
+            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt" line="93"
             column="49"/>
     </issue>
 
@@ -664,8 +757,7 @@
         errorLine1="        _columnsWorkouts.put(&quot;state&quot;, TableInfo.Column(&quot;state&quot;, &quot;TEXT&quot;, true, 0, null, TableInfo.CREATED_FROM_ENTITY))"
         errorLine2="                                                       ~~~~~~~">
         <location
-            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt"
-            line="91"
+            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt" line="93"
             column="56"/>
     </issue>
 
@@ -675,8 +767,7 @@
         errorLine1="        _columnsWorkouts.put(&quot;state&quot;, TableInfo.Column(&quot;state&quot;, &quot;TEXT&quot;, true, 0, null, TableInfo.CREATED_FROM_ENTITY))"
         errorLine2="                                                                ~~~~~~">
         <location
-            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt"
-            line="91"
+            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt" line="93"
             column="65"/>
     </issue>
 
@@ -686,8 +777,7 @@
         errorLine1="        _columnsWorkouts.put(&quot;state&quot;, TableInfo.Column(&quot;state&quot;, &quot;TEXT&quot;, true, 0, null, TableInfo.CREATED_FROM_ENTITY))"
         errorLine2="                                                                                 ~~~~">
         <location
-            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt"
-            line="91"
+            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt" line="93"
             column="82"/>
     </issue>
 
@@ -697,8 +787,7 @@
         errorLine1="        _columnsWorkouts.put(&quot;state&quot;, TableInfo.Column(&quot;state&quot;, &quot;TEXT&quot;, true, 0, null, TableInfo.CREATED_FROM_ENTITY))"
         errorLine2="                                                                                                 ~~~~~~~~~~~~~~~~~~~">
         <location
-            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt"
-            line="91"
+            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt" line="93"
             column="98"/>
     </issue>
 
@@ -708,8 +797,7 @@
         errorLine1="        _columnsWorkouts.put(&quot;timeElapsed&quot;, TableInfo.Column(&quot;timeElapsed&quot;, &quot;INTEGER&quot;, true, 0, null, TableInfo.CREATED_FROM_ENTITY))"
         errorLine2="                                                      ~~~~~~">
         <location
-            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt"
-            line="92"
+            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt" line="94"
             column="55"/>
     </issue>
 
@@ -719,8 +807,7 @@
         errorLine1="        _columnsWorkouts.put(&quot;timeElapsed&quot;, TableInfo.Column(&quot;timeElapsed&quot;, &quot;INTEGER&quot;, true, 0, null, TableInfo.CREATED_FROM_ENTITY))"
         errorLine2="                                                             ~~~~~~~~~~~~~">
         <location
-            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt"
-            line="92"
+            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt" line="94"
             column="62"/>
     </issue>
 
@@ -730,8 +817,7 @@
         errorLine1="        _columnsWorkouts.put(&quot;timeElapsed&quot;, TableInfo.Column(&quot;timeElapsed&quot;, &quot;INTEGER&quot;, true, 0, null, TableInfo.CREATED_FROM_ENTITY))"
         errorLine2="                                                                            ~~~~~~~~~">
         <location
-            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt"
-            line="92"
+            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt" line="94"
             column="77"/>
     </issue>
 
@@ -741,8 +827,7 @@
         errorLine1="        _columnsWorkouts.put(&quot;timeElapsed&quot;, TableInfo.Column(&quot;timeElapsed&quot;, &quot;INTEGER&quot;, true, 0, null, TableInfo.CREATED_FROM_ENTITY))"
         errorLine2="                                                                                                ~~~~">
         <location
-            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt"
-            line="92"
+            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt" line="94"
             column="97"/>
     </issue>
 
@@ -752,8 +837,7 @@
         errorLine1="        _columnsWorkouts.put(&quot;timeElapsed&quot;, TableInfo.Column(&quot;timeElapsed&quot;, &quot;INTEGER&quot;, true, 0, null, TableInfo.CREATED_FROM_ENTITY))"
         errorLine2="                                                                                                                ~~~~~~~~~~~~~~~~~~~">
         <location
-            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt"
-            line="92"
+            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt" line="94"
             column="113"/>
     </issue>
 
@@ -763,8 +847,7 @@
         errorLine1="        _columnsWorkouts.put(&quot;created&quot;, TableInfo.Column(&quot;created&quot;, &quot;TEXT&quot;, true, 0, null, TableInfo.CREATED_FROM_ENTITY))"
         errorLine2="                                                  ~~~~~~">
         <location
-            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt"
-            line="93"
+            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt" line="95"
             column="51"/>
     </issue>
 
@@ -774,8 +857,7 @@
         errorLine1="        _columnsWorkouts.put(&quot;created&quot;, TableInfo.Column(&quot;created&quot;, &quot;TEXT&quot;, true, 0, null, TableInfo.CREATED_FROM_ENTITY))"
         errorLine2="                                                         ~~~~~~~~~">
         <location
-            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt"
-            line="93"
+            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt" line="95"
             column="58"/>
     </issue>
 
@@ -785,8 +867,7 @@
         errorLine1="        _columnsWorkouts.put(&quot;created&quot;, TableInfo.Column(&quot;created&quot;, &quot;TEXT&quot;, true, 0, null, TableInfo.CREATED_FROM_ENTITY))"
         errorLine2="                                                                    ~~~~~~">
         <location
-            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt"
-            line="93"
+            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt" line="95"
             column="69"/>
     </issue>
 
@@ -796,8 +877,7 @@
         errorLine1="        _columnsWorkouts.put(&quot;created&quot;, TableInfo.Column(&quot;created&quot;, &quot;TEXT&quot;, true, 0, null, TableInfo.CREATED_FROM_ENTITY))"
         errorLine2="                                                                                     ~~~~">
         <location
-            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt"
-            line="93"
+            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt" line="95"
             column="86"/>
     </issue>
 
@@ -807,8 +887,7 @@
         errorLine1="        _columnsWorkouts.put(&quot;created&quot;, TableInfo.Column(&quot;created&quot;, &quot;TEXT&quot;, true, 0, null, TableInfo.CREATED_FROM_ENTITY))"
         errorLine2="                                                                                                     ~~~~~~~~~~~~~~~~~~~">
         <location
-            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt"
-            line="93"
+            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt" line="95"
             column="102"/>
     </issue>
 
@@ -818,8 +897,7 @@
         errorLine1="        _columnsWorkouts.put(&quot;completed&quot;, TableInfo.Column(&quot;completed&quot;, &quot;TEXT&quot;, true, 0, null, TableInfo.CREATED_FROM_ENTITY))"
         errorLine2="                                                    ~~~~~~">
         <location
-            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt"
-            line="94"
+            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt" line="96"
             column="53"/>
     </issue>
 
@@ -829,8 +907,7 @@
         errorLine1="        _columnsWorkouts.put(&quot;completed&quot;, TableInfo.Column(&quot;completed&quot;, &quot;TEXT&quot;, true, 0, null, TableInfo.CREATED_FROM_ENTITY))"
         errorLine2="                                                           ~~~~~~~~~~~">
         <location
-            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt"
-            line="94"
+            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt" line="96"
             column="60"/>
     </issue>
 
@@ -840,8 +917,7 @@
         errorLine1="        _columnsWorkouts.put(&quot;completed&quot;, TableInfo.Column(&quot;completed&quot;, &quot;TEXT&quot;, true, 0, null, TableInfo.CREATED_FROM_ENTITY))"
         errorLine2="                                                                        ~~~~~~">
         <location
-            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt"
-            line="94"
+            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt" line="96"
             column="73"/>
     </issue>
 
@@ -851,8 +927,7 @@
         errorLine1="        _columnsWorkouts.put(&quot;completed&quot;, TableInfo.Column(&quot;completed&quot;, &quot;TEXT&quot;, true, 0, null, TableInfo.CREATED_FROM_ENTITY))"
         errorLine2="                                                                                         ~~~~">
         <location
-            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt"
-            line="94"
+            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt" line="96"
             column="90"/>
     </issue>
 
@@ -862,8 +937,7 @@
         errorLine1="        _columnsWorkouts.put(&quot;completed&quot;, TableInfo.Column(&quot;completed&quot;, &quot;TEXT&quot;, true, 0, null, TableInfo.CREATED_FROM_ENTITY))"
         errorLine2="                                                                                                         ~~~~~~~~~~~~~~~~~~~">
         <location
-            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt"
-            line="94"
+            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt" line="96"
             column="106"/>
     </issue>
 
@@ -873,8 +947,7 @@
         errorLine1="        val _foreignKeysWorkouts: MutableSet&lt;TableInfo.ForeignKey> = mutableSetOf()"
         errorLine2="                                             ~~~~~~~~~~~~~~~~~~~~">
         <location
-            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt"
-            line="95"
+            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt" line="97"
             column="46"/>
     </issue>
 
@@ -884,8 +957,7 @@
         errorLine1="        val _indicesWorkouts: MutableSet&lt;TableInfo.Index> = mutableSetOf()"
         errorLine2="                                         ~~~~~~~~~~~~~~~">
         <location
-            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt"
-            line="96"
+            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt" line="98"
             column="42"/>
     </issue>
 
@@ -895,8 +967,7 @@
         errorLine1="        val _infoWorkouts: TableInfo = TableInfo(&quot;workouts&quot;, _columnsWorkouts, _foreignKeysWorkouts, _indicesWorkouts)"
         errorLine2="                           ~~~~~~~~~">
         <location
-            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt"
-            line="97"
+            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt" line="99"
             column="28"/>
     </issue>
 
@@ -906,8 +977,7 @@
         errorLine1="        val _infoWorkouts: TableInfo = TableInfo(&quot;workouts&quot;, _columnsWorkouts, _foreignKeysWorkouts, _indicesWorkouts)"
         errorLine2="                                       ~~~~~~~~~">
         <location
-            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt"
-            line="97"
+            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt" line="99"
             column="40"/>
     </issue>
 
@@ -917,8 +987,7 @@
         errorLine1="        val _infoWorkouts: TableInfo = TableInfo(&quot;workouts&quot;, _columnsWorkouts, _foreignKeysWorkouts, _indicesWorkouts)"
         errorLine2="                                                 ~~~~~~~~~~">
         <location
-            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt"
-            line="97"
+            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt" line="99"
             column="50"/>
     </issue>
 
@@ -928,8 +997,7 @@
         errorLine1="        val _infoWorkouts: TableInfo = TableInfo(&quot;workouts&quot;, _columnsWorkouts, _foreignKeysWorkouts, _indicesWorkouts)"
         errorLine2="                                                             ~~~~~~~~~~~~~~~~">
         <location
-            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt"
-            line="97"
+            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt" line="99"
             column="62"/>
     </issue>
 
@@ -939,8 +1007,7 @@
         errorLine1="        val _infoWorkouts: TableInfo = TableInfo(&quot;workouts&quot;, _columnsWorkouts, _foreignKeysWorkouts, _indicesWorkouts)"
         errorLine2="                                                                               ~~~~~~~~~~~~~~~~~~~~">
         <location
-            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt"
-            line="97"
+            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt" line="99"
             column="80"/>
     </issue>
 
@@ -950,8 +1017,7 @@
         errorLine1="        val _infoWorkouts: TableInfo = TableInfo(&quot;workouts&quot;, _columnsWorkouts, _foreignKeysWorkouts, _indicesWorkouts)"
         errorLine2="                                                                                                     ~~~~~~~~~~~~~~~~">
         <location
-            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt"
-            line="97"
+            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt" line="99"
             column="102"/>
     </issue>
 
@@ -961,8 +1027,7 @@
         errorLine1="        val _existingWorkouts: TableInfo = read(connection, &quot;workouts&quot;)"
         errorLine2="                                           ~~~~">
         <location
-            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt"
-            line="98"
+            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt" line="100"
             column="44"/>
     </issue>
 
@@ -972,8 +1037,7 @@
         errorLine1="        val _existingWorkouts: TableInfo = read(connection, &quot;workouts&quot;)"
         errorLine2="                                                ~~~~~~~~~~">
         <location
-            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt"
-            line="98"
+            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt" line="100"
             column="49"/>
     </issue>
 
@@ -983,8 +1047,7 @@
         errorLine1="        val _existingWorkouts: TableInfo = read(connection, &quot;workouts&quot;)"
         errorLine2="                                                            ~~~~~~~~~~">
         <location
-            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt"
-            line="98"
+            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt" line="100"
             column="61"/>
     </issue>
 
@@ -994,8 +1057,7 @@
         errorLine1="        val _existingWorkouts: TableInfo = read(connection, &quot;workouts&quot;)"
         errorLine2="                               ~~~~~~~~~">
         <location
-            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt"
-            line="98"
+            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt" line="100"
             column="32"/>
     </issue>
 
@@ -1005,8 +1067,7 @@
         errorLine1="        if (!_infoWorkouts.equals(_existingWorkouts)) {"
         errorLine2="                           ~~~~~~">
         <location
-            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt"
-            line="99"
+            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt" line="101"
             column="28"/>
     </issue>
 
@@ -1016,8 +1077,7 @@
         errorLine1="        if (!_infoWorkouts.equals(_existingWorkouts)) {"
         errorLine2="                                  ~~~~~~~~~~~~~~~~~">
         <location
-            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt"
-            line="99"
+            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt" line="101"
             column="35"/>
     </issue>
 
@@ -1027,8 +1087,7 @@
         errorLine1="          return RoomOpenDelegate.ValidationResult(false, &quot;&quot;&quot;"
         errorLine2="                                  ~~~~~~~~~~~~~~~~">
         <location
-            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt"
-            line="100"
+            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt" line="102"
             column="35"/>
     </issue>
 
@@ -1038,8 +1097,7 @@
         errorLine1="          return RoomOpenDelegate.ValidationResult(false, &quot;&quot;&quot;"
         errorLine2="                                                          ^">
         <location
-            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt"
-            line="100"
+            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt" line="102"
             column="59"/>
     </issue>
 
@@ -1049,8 +1107,7 @@
         errorLine1="        val _columnsExercises: MutableMap&lt;String, TableInfo.Column> = mutableMapOf()"
         errorLine2="                                                  ~~~~~~~~~~~~~~~~">
         <location
-            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt"
-            line="108"
+            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt" line="110"
             column="51"/>
     </issue>
 
@@ -1060,8 +1117,7 @@
         errorLine1="        _columnsExercises.put(&quot;id&quot;, TableInfo.Column(&quot;id&quot;, &quot;INTEGER&quot;, true, 1, null, TableInfo.CREATED_FROM_ENTITY))"
         errorLine2="                                              ~~~~~~">
         <location
-            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt"
-            line="109"
+            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt" line="111"
             column="47"/>
     </issue>
 
@@ -1071,8 +1127,7 @@
         errorLine1="        _columnsExercises.put(&quot;id&quot;, TableInfo.Column(&quot;id&quot;, &quot;INTEGER&quot;, true, 1, null, TableInfo.CREATED_FROM_ENTITY))"
         errorLine2="                                                     ~~~~">
         <location
-            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt"
-            line="109"
+            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt" line="111"
             column="54"/>
     </issue>
 
@@ -1082,8 +1137,7 @@
         errorLine1="        _columnsExercises.put(&quot;id&quot;, TableInfo.Column(&quot;id&quot;, &quot;INTEGER&quot;, true, 1, null, TableInfo.CREATED_FROM_ENTITY))"
         errorLine2="                                                           ~~~~~~~~~">
         <location
-            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt"
-            line="109"
+            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt" line="111"
             column="60"/>
     </issue>
 
@@ -1093,8 +1147,7 @@
         errorLine1="        _columnsExercises.put(&quot;id&quot;, TableInfo.Column(&quot;id&quot;, &quot;INTEGER&quot;, true, 1, null, TableInfo.CREATED_FROM_ENTITY))"
         errorLine2="                                                                               ~~~~">
         <location
-            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt"
-            line="109"
+            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt" line="111"
             column="80"/>
     </issue>
 
@@ -1104,8 +1157,7 @@
         errorLine1="        _columnsExercises.put(&quot;id&quot;, TableInfo.Column(&quot;id&quot;, &quot;INTEGER&quot;, true, 1, null, TableInfo.CREATED_FROM_ENTITY))"
         errorLine2="                                                                                               ~~~~~~~~~~~~~~~~~~~">
         <location
-            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt"
-            line="109"
+            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt" line="111"
             column="96"/>
     </issue>
 
@@ -1115,8 +1167,7 @@
         errorLine1="        _columnsExercises.put(&quot;idExerciseDC&quot;, TableInfo.Column(&quot;idExerciseDC&quot;, &quot;TEXT&quot;, true, 0, null, TableInfo.CREATED_FROM_ENTITY))"
         errorLine2="                                                        ~~~~~~">
         <location
-            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt"
-            line="110"
+            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt" line="112"
             column="57"/>
     </issue>
 
@@ -1126,8 +1177,7 @@
         errorLine1="        _columnsExercises.put(&quot;idExerciseDC&quot;, TableInfo.Column(&quot;idExerciseDC&quot;, &quot;TEXT&quot;, true, 0, null, TableInfo.CREATED_FROM_ENTITY))"
         errorLine2="                                                               ~~~~~~~~~~~~~~">
         <location
-            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt"
-            line="110"
+            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt" line="112"
             column="64"/>
     </issue>
 
@@ -1137,8 +1187,7 @@
         errorLine1="        _columnsExercises.put(&quot;idExerciseDC&quot;, TableInfo.Column(&quot;idExerciseDC&quot;, &quot;TEXT&quot;, true, 0, null, TableInfo.CREATED_FROM_ENTITY))"
         errorLine2="                                                                               ~~~~~~">
         <location
-            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt"
-            line="110"
+            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt" line="112"
             column="80"/>
     </issue>
 
@@ -1148,8 +1197,7 @@
         errorLine1="        _columnsExercises.put(&quot;idExerciseDC&quot;, TableInfo.Column(&quot;idExerciseDC&quot;, &quot;TEXT&quot;, true, 0, null, TableInfo.CREATED_FROM_ENTITY))"
         errorLine2="                                                                                                ~~~~">
         <location
-            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt"
-            line="110"
+            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt" line="112"
             column="97"/>
     </issue>
 
@@ -1159,8 +1207,7 @@
         errorLine1="        _columnsExercises.put(&quot;idExerciseDC&quot;, TableInfo.Column(&quot;idExerciseDC&quot;, &quot;TEXT&quot;, true, 0, null, TableInfo.CREATED_FROM_ENTITY))"
         errorLine2="                                                                                                                ~~~~~~~~~~~~~~~~~~~">
         <location
-            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt"
-            line="110"
+            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt" line="112"
             column="113"/>
     </issue>
 
@@ -1170,8 +1217,7 @@
         errorLine1="        _columnsExercises.put(&quot;notes&quot;, TableInfo.Column(&quot;notes&quot;, &quot;TEXT&quot;, true, 0, null, TableInfo.CREATED_FROM_ENTITY))"
         errorLine2="                                                 ~~~~~~">
         <location
-            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt"
-            line="111"
+            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt" line="113"
             column="50"/>
     </issue>
 
@@ -1181,8 +1227,7 @@
         errorLine1="        _columnsExercises.put(&quot;notes&quot;, TableInfo.Column(&quot;notes&quot;, &quot;TEXT&quot;, true, 0, null, TableInfo.CREATED_FROM_ENTITY))"
         errorLine2="                                                        ~~~~~~~">
         <location
-            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt"
-            line="111"
+            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt" line="113"
             column="57"/>
     </issue>
 
@@ -1192,8 +1237,7 @@
         errorLine1="        _columnsExercises.put(&quot;notes&quot;, TableInfo.Column(&quot;notes&quot;, &quot;TEXT&quot;, true, 0, null, TableInfo.CREATED_FROM_ENTITY))"
         errorLine2="                                                                 ~~~~~~">
         <location
-            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt"
-            line="111"
+            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt" line="113"
             column="66"/>
     </issue>
 
@@ -1203,8 +1247,7 @@
         errorLine1="        _columnsExercises.put(&quot;notes&quot;, TableInfo.Column(&quot;notes&quot;, &quot;TEXT&quot;, true, 0, null, TableInfo.CREATED_FROM_ENTITY))"
         errorLine2="                                                                                  ~~~~">
         <location
-            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt"
-            line="111"
+            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt" line="113"
             column="83"/>
     </issue>
 
@@ -1214,8 +1257,7 @@
         errorLine1="        _columnsExercises.put(&quot;notes&quot;, TableInfo.Column(&quot;notes&quot;, &quot;TEXT&quot;, true, 0, null, TableInfo.CREATED_FROM_ENTITY))"
         errorLine2="                                                                                                  ~~~~~~~~~~~~~~~~~~~">
         <location
-            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt"
-            line="111"
+            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt" line="113"
             column="99"/>
     </issue>
 
@@ -1225,8 +1267,7 @@
         errorLine1="        _columnsExercises.put(&quot;setMode&quot;, TableInfo.Column(&quot;setMode&quot;, &quot;TEXT&quot;, true, 0, null, TableInfo.CREATED_FROM_ENTITY))"
         errorLine2="                                                   ~~~~~~">
         <location
-            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt"
-            line="112"
+            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt" line="114"
             column="52"/>
     </issue>
 
@@ -1236,8 +1277,7 @@
         errorLine1="        _columnsExercises.put(&quot;setMode&quot;, TableInfo.Column(&quot;setMode&quot;, &quot;TEXT&quot;, true, 0, null, TableInfo.CREATED_FROM_ENTITY))"
         errorLine2="                                                          ~~~~~~~~~">
         <location
-            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt"
-            line="112"
+            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt" line="114"
             column="59"/>
     </issue>
 
@@ -1247,8 +1287,7 @@
         errorLine1="        _columnsExercises.put(&quot;setMode&quot;, TableInfo.Column(&quot;setMode&quot;, &quot;TEXT&quot;, true, 0, null, TableInfo.CREATED_FROM_ENTITY))"
         errorLine2="                                                                     ~~~~~~">
         <location
-            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt"
-            line="112"
+            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt" line="114"
             column="70"/>
     </issue>
 
@@ -1258,8 +1297,7 @@
         errorLine1="        _columnsExercises.put(&quot;setMode&quot;, TableInfo.Column(&quot;setMode&quot;, &quot;TEXT&quot;, true, 0, null, TableInfo.CREATED_FROM_ENTITY))"
         errorLine2="                                                                                      ~~~~">
         <location
-            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt"
-            line="112"
+            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt" line="114"
             column="87"/>
     </issue>
 
@@ -1269,8 +1307,7 @@
         errorLine1="        _columnsExercises.put(&quot;setMode&quot;, TableInfo.Column(&quot;setMode&quot;, &quot;TEXT&quot;, true, 0, null, TableInfo.CREATED_FROM_ENTITY))"
         errorLine2="                                                                                                      ~~~~~~~~~~~~~~~~~~~">
         <location
-            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt"
-            line="112"
+            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt" line="114"
             column="103"/>
     </issue>
 
@@ -1280,8 +1317,7 @@
         errorLine1="        _columnsExercises.put(&quot;restTime&quot;, TableInfo.Column(&quot;restTime&quot;, &quot;INTEGER&quot;, true, 0, null, TableInfo.CREATED_FROM_ENTITY))"
         errorLine2="                                                    ~~~~~~">
         <location
-            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt"
-            line="113"
+            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt" line="115"
             column="53"/>
     </issue>
 
@@ -1291,8 +1327,7 @@
         errorLine1="        _columnsExercises.put(&quot;restTime&quot;, TableInfo.Column(&quot;restTime&quot;, &quot;INTEGER&quot;, true, 0, null, TableInfo.CREATED_FROM_ENTITY))"
         errorLine2="                                                           ~~~~~~~~~~">
         <location
-            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt"
-            line="113"
+            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt" line="115"
             column="60"/>
     </issue>
 
@@ -1302,8 +1337,7 @@
         errorLine1="        _columnsExercises.put(&quot;restTime&quot;, TableInfo.Column(&quot;restTime&quot;, &quot;INTEGER&quot;, true, 0, null, TableInfo.CREATED_FROM_ENTITY))"
         errorLine2="                                                                       ~~~~~~~~~">
         <location
-            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt"
-            line="113"
+            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt" line="115"
             column="72"/>
     </issue>
 
@@ -1313,8 +1347,7 @@
         errorLine1="        _columnsExercises.put(&quot;restTime&quot;, TableInfo.Column(&quot;restTime&quot;, &quot;INTEGER&quot;, true, 0, null, TableInfo.CREATED_FROM_ENTITY))"
         errorLine2="                                                                                           ~~~~">
         <location
-            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt"
-            line="113"
+            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt" line="115"
             column="92"/>
     </issue>
 
@@ -1324,8 +1357,48 @@
         errorLine1="        _columnsExercises.put(&quot;restTime&quot;, TableInfo.Column(&quot;restTime&quot;, &quot;INTEGER&quot;, true, 0, null, TableInfo.CREATED_FROM_ENTITY))"
         errorLine2="                                                                                                           ~~~~~~~~~~~~~~~~~~~">
         <location
-            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt"
-            line="113"
+            column="108" file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt"
+            line="115" />
+    </issue>
+
+    <issue errorLine1="        _columnsExercises.put(&quot;position&quot;, TableInfo.Column(&quot;position&quot;, &quot;INTEGER&quot;, true, 0, null, TableInfo.CREATED_FROM_ENTITY))"
+        errorLine2="                                                    ~~~~~~"
+        id="RestrictedApi"
+        message="Column can only be called from within the same library group prefix (referenced groupId=`androidx.room` with prefix androidx from groupId=`LibreFit`)">
+        <location column="53"
+            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt" line="116" />
+    </issue>
+
+    <issue errorLine1="        _columnsExercises.put(&quot;position&quot;, TableInfo.Column(&quot;position&quot;, &quot;INTEGER&quot;, true, 0, null, TableInfo.CREATED_FROM_ENTITY))"
+        errorLine2="                                                           ~~~~~~~~~~"
+        id="RestrictedApi"
+        message="Column can only be called from within the same library group prefix (referenced groupId=`androidx.room` with prefix androidx from groupId=`LibreFit`)">
+        <location column="60"
+            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt" line="116" />
+    </issue>
+
+    <issue errorLine1="        _columnsExercises.put(&quot;position&quot;, TableInfo.Column(&quot;position&quot;, &quot;INTEGER&quot;, true, 0, null, TableInfo.CREATED_FROM_ENTITY))"
+        errorLine2="                                                                       ~~~~~~~~~"
+        id="RestrictedApi"
+        message="Column can only be called from within the same library group prefix (referenced groupId=`androidx.room` with prefix androidx from groupId=`LibreFit`)">
+        <location column="72"
+            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt" line="116" />
+    </issue>
+
+    <issue errorLine1="        _columnsExercises.put(&quot;position&quot;, TableInfo.Column(&quot;position&quot;, &quot;INTEGER&quot;, true, 0, null, TableInfo.CREATED_FROM_ENTITY))"
+        errorLine2="                                                                                           ~~~~"
+        id="RestrictedApi"
+        message="Column can only be called from within the same library group prefix (referenced groupId=`androidx.room` with prefix androidx from groupId=`LibreFit`)">
+        <location column="92"
+            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt" line="116" />
+    </issue>
+
+    <issue errorLine1="        _columnsExercises.put(&quot;position&quot;, TableInfo.Column(&quot;position&quot;, &quot;INTEGER&quot;, true, 0, null, TableInfo.CREATED_FROM_ENTITY))"
+        errorLine2="                                                                                                           ~~~~~~~~~~~~~~~~~~~"
+        id="RestrictedApi"
+        message="TableInfo.CREATED_FROM_ENTITY can only be accessed from within the same library group prefix (referenced groupId=`androidx.room` with prefix androidx from groupId=`LibreFit`)">
+        <location file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt"
+            line="116"
             column="108"/>
     </issue>
 
@@ -1335,8 +1408,7 @@
         errorLine1="        _columnsExercises.put(&quot;workoutId&quot;, TableInfo.Column(&quot;workoutId&quot;, &quot;INTEGER&quot;, true, 0, null, TableInfo.CREATED_FROM_ENTITY))"
         errorLine2="                                                     ~~~~~~">
         <location
-            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt"
-            line="114"
+            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt" line="117"
             column="54"/>
     </issue>
 
@@ -1346,8 +1418,7 @@
         errorLine1="        _columnsExercises.put(&quot;workoutId&quot;, TableInfo.Column(&quot;workoutId&quot;, &quot;INTEGER&quot;, true, 0, null, TableInfo.CREATED_FROM_ENTITY))"
         errorLine2="                                                            ~~~~~~~~~~~">
         <location
-            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt"
-            line="114"
+            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt" line="117"
             column="61"/>
     </issue>
 
@@ -1357,8 +1428,7 @@
         errorLine1="        _columnsExercises.put(&quot;workoutId&quot;, TableInfo.Column(&quot;workoutId&quot;, &quot;INTEGER&quot;, true, 0, null, TableInfo.CREATED_FROM_ENTITY))"
         errorLine2="                                                                         ~~~~~~~~~">
         <location
-            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt"
-            line="114"
+            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt" line="117"
             column="74"/>
     </issue>
 
@@ -1368,8 +1438,7 @@
         errorLine1="        _columnsExercises.put(&quot;workoutId&quot;, TableInfo.Column(&quot;workoutId&quot;, &quot;INTEGER&quot;, true, 0, null, TableInfo.CREATED_FROM_ENTITY))"
         errorLine2="                                                                                             ~~~~">
         <location
-            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt"
-            line="114"
+            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt" line="117"
             column="94"/>
     </issue>
 
@@ -1379,8 +1448,7 @@
         errorLine1="        _columnsExercises.put(&quot;workoutId&quot;, TableInfo.Column(&quot;workoutId&quot;, &quot;INTEGER&quot;, true, 0, null, TableInfo.CREATED_FROM_ENTITY))"
         errorLine2="                                                                                                             ~~~~~~~~~~~~~~~~~~~">
         <location
-            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt"
-            line="114"
+            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt" line="117"
             column="110"/>
     </issue>
 
@@ -1390,8 +1458,7 @@
         errorLine1="        val _foreignKeysExercises: MutableSet&lt;TableInfo.ForeignKey> = mutableSetOf()"
         errorLine2="                                              ~~~~~~~~~~~~~~~~~~~~">
         <location
-            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt"
-            line="115"
+            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt" line="118"
             column="47"/>
     </issue>
 
@@ -1401,8 +1468,7 @@
         errorLine1="        _foreignKeysExercises.add(TableInfo.ForeignKey(&quot;workouts&quot;, &quot;CASCADE&quot;, &quot;NO ACTION&quot;, listOf(&quot;workoutId&quot;), listOf(&quot;id&quot;)))"
         errorLine2="                                            ~~~~~~~~~~">
         <location
-            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt"
-            line="116"
+            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt" line="119"
             column="45"/>
     </issue>
 
@@ -1412,8 +1478,7 @@
         errorLine1="        _foreignKeysExercises.add(TableInfo.ForeignKey(&quot;workouts&quot;, &quot;CASCADE&quot;, &quot;NO ACTION&quot;, listOf(&quot;workoutId&quot;), listOf(&quot;id&quot;)))"
         errorLine2="                                                       ~~~~~~~~~~">
         <location
-            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt"
-            line="116"
+            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt" line="119"
             column="56"/>
     </issue>
 
@@ -1423,8 +1488,7 @@
         errorLine1="        _foreignKeysExercises.add(TableInfo.ForeignKey(&quot;workouts&quot;, &quot;CASCADE&quot;, &quot;NO ACTION&quot;, listOf(&quot;workoutId&quot;), listOf(&quot;id&quot;)))"
         errorLine2="                                                                   ~~~~~~~~~">
         <location
-            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt"
-            line="116"
+            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt" line="119"
             column="68"/>
     </issue>
 
@@ -1434,8 +1498,7 @@
         errorLine1="        _foreignKeysExercises.add(TableInfo.ForeignKey(&quot;workouts&quot;, &quot;CASCADE&quot;, &quot;NO ACTION&quot;, listOf(&quot;workoutId&quot;), listOf(&quot;id&quot;)))"
         errorLine2="                                                                              ~~~~~~~~~~~">
         <location
-            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt"
-            line="116"
+            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt" line="119"
             column="79"/>
     </issue>
 
@@ -1445,8 +1508,7 @@
         errorLine1="        _foreignKeysExercises.add(TableInfo.ForeignKey(&quot;workouts&quot;, &quot;CASCADE&quot;, &quot;NO ACTION&quot;, listOf(&quot;workoutId&quot;), listOf(&quot;id&quot;)))"
         errorLine2="                                                                                           ~~~~~~">
         <location
-            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt"
-            line="116"
+            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt" line="119"
             column="92"/>
     </issue>
 
@@ -1456,8 +1518,7 @@
         errorLine1="        _foreignKeysExercises.add(TableInfo.ForeignKey(&quot;workouts&quot;, &quot;CASCADE&quot;, &quot;NO ACTION&quot;, listOf(&quot;workoutId&quot;), listOf(&quot;id&quot;)))"
         errorLine2="                                                                                                                ~~~~~~">
         <location
-            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt"
-            line="116"
+            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt" line="119"
             column="113"/>
     </issue>
 
@@ -1467,8 +1528,7 @@
         errorLine1="        _foreignKeysExercises.add(TableInfo.ForeignKey(&quot;dataset&quot;, &quot;CASCADE&quot;, &quot;NO ACTION&quot;, listOf(&quot;idExerciseDC&quot;), listOf(&quot;id&quot;)))"
         errorLine2="                                            ~~~~~~~~~~">
         <location
-            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt"
-            line="117"
+            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt" line="120"
             column="45"/>
     </issue>
 
@@ -1478,8 +1538,7 @@
         errorLine1="        _foreignKeysExercises.add(TableInfo.ForeignKey(&quot;dataset&quot;, &quot;CASCADE&quot;, &quot;NO ACTION&quot;, listOf(&quot;idExerciseDC&quot;), listOf(&quot;id&quot;)))"
         errorLine2="                                                       ~~~~~~~~~">
         <location
-            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt"
-            line="117"
+            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt" line="120"
             column="56"/>
     </issue>
 
@@ -1489,8 +1548,7 @@
         errorLine1="        _foreignKeysExercises.add(TableInfo.ForeignKey(&quot;dataset&quot;, &quot;CASCADE&quot;, &quot;NO ACTION&quot;, listOf(&quot;idExerciseDC&quot;), listOf(&quot;id&quot;)))"
         errorLine2="                                                                  ~~~~~~~~~">
         <location
-            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt"
-            line="117"
+            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt" line="120"
             column="67"/>
     </issue>
 
@@ -1500,8 +1558,7 @@
         errorLine1="        _foreignKeysExercises.add(TableInfo.ForeignKey(&quot;dataset&quot;, &quot;CASCADE&quot;, &quot;NO ACTION&quot;, listOf(&quot;idExerciseDC&quot;), listOf(&quot;id&quot;)))"
         errorLine2="                                                                             ~~~~~~~~~~~">
         <location
-            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt"
-            line="117"
+            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt" line="120"
             column="78"/>
     </issue>
 
@@ -1511,8 +1568,7 @@
         errorLine1="        _foreignKeysExercises.add(TableInfo.ForeignKey(&quot;dataset&quot;, &quot;CASCADE&quot;, &quot;NO ACTION&quot;, listOf(&quot;idExerciseDC&quot;), listOf(&quot;id&quot;)))"
         errorLine2="                                                                                          ~~~~~~">
         <location
-            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt"
-            line="117"
+            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt" line="120"
             column="91"/>
     </issue>
 
@@ -1522,8 +1578,7 @@
         errorLine1="        _foreignKeysExercises.add(TableInfo.ForeignKey(&quot;dataset&quot;, &quot;CASCADE&quot;, &quot;NO ACTION&quot;, listOf(&quot;idExerciseDC&quot;), listOf(&quot;id&quot;)))"
         errorLine2="                                                                                                                  ~~~~~~">
         <location
-            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt"
-            line="117"
+            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt" line="120"
             column="115"/>
     </issue>
 
@@ -1533,8 +1588,7 @@
         errorLine1="        val _indicesExercises: MutableSet&lt;TableInfo.Index> = mutableSetOf()"
         errorLine2="                                          ~~~~~~~~~~~~~~~">
         <location
-            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt"
-            line="118"
+            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt" line="121"
             column="43"/>
     </issue>
 
@@ -1544,8 +1598,7 @@
         errorLine1="        _indicesExercises.add(TableInfo.Index(&quot;index_exercises_workoutId&quot;, false, listOf(&quot;workoutId&quot;), listOf(&quot;ASC&quot;)))"
         errorLine2="                                        ~~~~~">
         <location
-            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt"
-            line="119"
+            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt" line="122"
             column="41"/>
     </issue>
 
@@ -1555,8 +1608,7 @@
         errorLine1="        _indicesExercises.add(TableInfo.Index(&quot;index_exercises_workoutId&quot;, false, listOf(&quot;workoutId&quot;), listOf(&quot;ASC&quot;)))"
         errorLine2="                                              ~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
-            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt"
-            line="119"
+            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt" line="122"
             column="47"/>
     </issue>
 
@@ -1566,8 +1618,7 @@
         errorLine1="        _indicesExercises.add(TableInfo.Index(&quot;index_exercises_workoutId&quot;, false, listOf(&quot;workoutId&quot;), listOf(&quot;ASC&quot;)))"
         errorLine2="                                                                                  ~~~~~~">
         <location
-            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt"
-            line="119"
+            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt" line="122"
             column="83"/>
     </issue>
 
@@ -1577,9 +1628,72 @@
         errorLine1="        _indicesExercises.add(TableInfo.Index(&quot;index_exercises_workoutId&quot;, false, listOf(&quot;workoutId&quot;), listOf(&quot;ASC&quot;)))"
         errorLine2="                                                                                                       ~~~~~~">
         <location
-            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt"
-            line="119"
+            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt" line="122"
             column="104"/>
+    </issue>
+
+    <issue errorLine1="        _indicesExercises.add(TableInfo.Index(&quot;index_exercises_workoutId_position&quot;, false, listOf(&quot;workoutId&quot;, &quot;position&quot;), listOf(&quot;ASC&quot;, &quot;ASC&quot;)))"
+        errorLine2="                                        ~~~~~"
+        id="RestrictedApi"
+        message="Index can only be called from within the same library group prefix (referenced groupId=`androidx.room` with prefix androidx from groupId=`LibreFit`)">
+        <location column="41"
+            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt" line="123" />
+    </issue>
+
+    <issue errorLine1="        _indicesExercises.add(TableInfo.Index(&quot;index_exercises_workoutId_position&quot;, false, listOf(&quot;workoutId&quot;, &quot;position&quot;), listOf(&quot;ASC&quot;, &quot;ASC&quot;)))"
+        errorLine2="                                              ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~"
+        id="RestrictedApi"
+        message="Index can only be called from within the same library group prefix (referenced groupId=`androidx.room` with prefix androidx from groupId=`LibreFit`)">
+        <location column="47"
+            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt" line="123" />
+    </issue>
+
+    <issue errorLine1="        _indicesExercises.add(TableInfo.Index(&quot;index_exercises_workoutId_position&quot;, false, listOf(&quot;workoutId&quot;, &quot;position&quot;), listOf(&quot;ASC&quot;, &quot;ASC&quot;)))"
+        errorLine2="                                                                                           ~~~~~~"
+        id="RestrictedApi"
+        message="Index can only be called from within the same library group prefix (referenced groupId=`androidx.room` with prefix androidx from groupId=`LibreFit`)">
+        <location column="92"
+            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt" line="123" />
+    </issue>
+
+    <issue errorLine1="        _indicesExercises.add(TableInfo.Index(&quot;index_exercises_workoutId_position&quot;, false, listOf(&quot;workoutId&quot;, &quot;position&quot;), listOf(&quot;ASC&quot;, &quot;ASC&quot;)))"
+        errorLine2="                                                                                                                            ~~~~~~"
+        id="RestrictedApi"
+        message="Index can only be called from within the same library group prefix (referenced groupId=`androidx.room` with prefix androidx from groupId=`LibreFit`)">
+        <location column="125"
+            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt" line="123" />
+    </issue>
+
+    <issue errorLine1="        _indicesExercises.add(TableInfo.Index(&quot;index_exercises_idExerciseDC&quot;, false, listOf(&quot;idExerciseDC&quot;), listOf(&quot;ASC&quot;)))"
+        errorLine2="                                        ~~~~~"
+        id="RestrictedApi"
+        message="Index can only be called from within the same library group prefix (referenced groupId=`androidx.room` with prefix androidx from groupId=`LibreFit`)">
+        <location column="41"
+            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt" line="124" />
+    </issue>
+
+    <issue errorLine1="        _indicesExercises.add(TableInfo.Index(&quot;index_exercises_idExerciseDC&quot;, false, listOf(&quot;idExerciseDC&quot;), listOf(&quot;ASC&quot;)))"
+        errorLine2="                                              ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~"
+        id="RestrictedApi"
+        message="Index can only be called from within the same library group prefix (referenced groupId=`androidx.room` with prefix androidx from groupId=`LibreFit`)">
+        <location column="47"
+            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt" line="124" />
+    </issue>
+
+    <issue errorLine1="        _indicesExercises.add(TableInfo.Index(&quot;index_exercises_idExerciseDC&quot;, false, listOf(&quot;idExerciseDC&quot;), listOf(&quot;ASC&quot;)))"
+        errorLine2="                                                                                     ~~~~~~"
+        id="RestrictedApi"
+        message="Index can only be called from within the same library group prefix (referenced groupId=`androidx.room` with prefix androidx from groupId=`LibreFit`)">
+        <location column="86"
+            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt" line="124" />
+    </issue>
+
+    <issue errorLine1="        _indicesExercises.add(TableInfo.Index(&quot;index_exercises_idExerciseDC&quot;, false, listOf(&quot;idExerciseDC&quot;), listOf(&quot;ASC&quot;)))"
+        errorLine2="                                                                                                             ~~~~~~"
+        id="RestrictedApi"
+        message="Index can only be called from within the same library group prefix (referenced groupId=`androidx.room` with prefix androidx from groupId=`LibreFit`)">
+        <location column="110"
+            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt" line="124" />
     </issue>
 
     <issue
@@ -1588,8 +1702,7 @@
         errorLine1="        val _infoExercises: TableInfo = TableInfo(&quot;exercises&quot;, _columnsExercises, _foreignKeysExercises, _indicesExercises)"
         errorLine2="                            ~~~~~~~~~">
         <location
-            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt"
-            line="120"
+            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt" line="125"
             column="29"/>
     </issue>
 
@@ -1599,8 +1712,7 @@
         errorLine1="        val _infoExercises: TableInfo = TableInfo(&quot;exercises&quot;, _columnsExercises, _foreignKeysExercises, _indicesExercises)"
         errorLine2="                                        ~~~~~~~~~">
         <location
-            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt"
-            line="120"
+            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt" line="125"
             column="41"/>
     </issue>
 
@@ -1610,8 +1722,7 @@
         errorLine1="        val _infoExercises: TableInfo = TableInfo(&quot;exercises&quot;, _columnsExercises, _foreignKeysExercises, _indicesExercises)"
         errorLine2="                                                  ~~~~~~~~~~~">
         <location
-            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt"
-            line="120"
+            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt" line="125"
             column="51"/>
     </issue>
 
@@ -1621,8 +1732,7 @@
         errorLine1="        val _infoExercises: TableInfo = TableInfo(&quot;exercises&quot;, _columnsExercises, _foreignKeysExercises, _indicesExercises)"
         errorLine2="                                                               ~~~~~~~~~~~~~~~~~">
         <location
-            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt"
-            line="120"
+            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt" line="125"
             column="64"/>
     </issue>
 
@@ -1632,8 +1742,7 @@
         errorLine1="        val _infoExercises: TableInfo = TableInfo(&quot;exercises&quot;, _columnsExercises, _foreignKeysExercises, _indicesExercises)"
         errorLine2="                                                                                  ~~~~~~~~~~~~~~~~~~~~~">
         <location
-            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt"
-            line="120"
+            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt" line="125"
             column="83"/>
     </issue>
 
@@ -1643,8 +1752,7 @@
         errorLine1="        val _infoExercises: TableInfo = TableInfo(&quot;exercises&quot;, _columnsExercises, _foreignKeysExercises, _indicesExercises)"
         errorLine2="                                                                                                         ~~~~~~~~~~~~~~~~~">
         <location
-            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt"
-            line="120"
+            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt" line="125"
             column="106"/>
     </issue>
 
@@ -1654,8 +1762,7 @@
         errorLine1="        val _existingExercises: TableInfo = read(connection, &quot;exercises&quot;)"
         errorLine2="                                            ~~~~">
         <location
-            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt"
-            line="121"
+            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt" line="126"
             column="45"/>
     </issue>
 
@@ -1665,8 +1772,7 @@
         errorLine1="        val _existingExercises: TableInfo = read(connection, &quot;exercises&quot;)"
         errorLine2="                                                 ~~~~~~~~~~">
         <location
-            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt"
-            line="121"
+            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt" line="126"
             column="50"/>
     </issue>
 
@@ -1676,8 +1782,7 @@
         errorLine1="        val _existingExercises: TableInfo = read(connection, &quot;exercises&quot;)"
         errorLine2="                                                             ~~~~~~~~~~~">
         <location
-            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt"
-            line="121"
+            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt" line="126"
             column="62"/>
     </issue>
 
@@ -1687,8 +1792,7 @@
         errorLine1="        val _existingExercises: TableInfo = read(connection, &quot;exercises&quot;)"
         errorLine2="                                ~~~~~~~~~">
         <location
-            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt"
-            line="121"
+            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt" line="126"
             column="33"/>
     </issue>
 
@@ -1698,8 +1802,7 @@
         errorLine1="        if (!_infoExercises.equals(_existingExercises)) {"
         errorLine2="                            ~~~~~~">
         <location
-            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt"
-            line="122"
+            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt" line="127"
             column="29"/>
     </issue>
 
@@ -1709,8 +1812,7 @@
         errorLine1="        if (!_infoExercises.equals(_existingExercises)) {"
         errorLine2="                                   ~~~~~~~~~~~~~~~~~~">
         <location
-            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt"
-            line="122"
+            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt" line="127"
             column="36"/>
     </issue>
 
@@ -1720,8 +1822,7 @@
         errorLine1="          return RoomOpenDelegate.ValidationResult(false, &quot;&quot;&quot;"
         errorLine2="                                  ~~~~~~~~~~~~~~~~">
         <location
-            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt"
-            line="123"
+            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt" line="128"
             column="35"/>
     </issue>
 
@@ -1731,8 +1832,7 @@
         errorLine1="          return RoomOpenDelegate.ValidationResult(false, &quot;&quot;&quot;"
         errorLine2="                                                          ^">
         <location
-            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt"
-            line="123"
+            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt" line="128"
             column="59"/>
     </issue>
 
@@ -1742,8 +1842,7 @@
         errorLine1="        val _columnsSets: MutableMap&lt;String, TableInfo.Column> = mutableMapOf()"
         errorLine2="                                             ~~~~~~~~~~~~~~~~">
         <location
-            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt"
-            line="131"
+            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt" line="136"
             column="46"/>
     </issue>
 
@@ -1753,8 +1852,7 @@
         errorLine1="        _columnsSets.put(&quot;id&quot;, TableInfo.Column(&quot;id&quot;, &quot;INTEGER&quot;, true, 1, null, TableInfo.CREATED_FROM_ENTITY))"
         errorLine2="                                         ~~~~~~">
         <location
-            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt"
-            line="132"
+            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt" line="137"
             column="42"/>
     </issue>
 
@@ -1764,8 +1862,7 @@
         errorLine1="        _columnsSets.put(&quot;id&quot;, TableInfo.Column(&quot;id&quot;, &quot;INTEGER&quot;, true, 1, null, TableInfo.CREATED_FROM_ENTITY))"
         errorLine2="                                                ~~~~">
         <location
-            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt"
-            line="132"
+            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt" line="137"
             column="49"/>
     </issue>
 
@@ -1775,8 +1872,7 @@
         errorLine1="        _columnsSets.put(&quot;id&quot;, TableInfo.Column(&quot;id&quot;, &quot;INTEGER&quot;, true, 1, null, TableInfo.CREATED_FROM_ENTITY))"
         errorLine2="                                                      ~~~~~~~~~">
         <location
-            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt"
-            line="132"
+            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt" line="137"
             column="55"/>
     </issue>
 
@@ -1786,8 +1882,7 @@
         errorLine1="        _columnsSets.put(&quot;id&quot;, TableInfo.Column(&quot;id&quot;, &quot;INTEGER&quot;, true, 1, null, TableInfo.CREATED_FROM_ENTITY))"
         errorLine2="                                                                          ~~~~">
         <location
-            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt"
-            line="132"
+            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt" line="137"
             column="75"/>
     </issue>
 
@@ -1797,8 +1892,7 @@
         errorLine1="        _columnsSets.put(&quot;id&quot;, TableInfo.Column(&quot;id&quot;, &quot;INTEGER&quot;, true, 1, null, TableInfo.CREATED_FROM_ENTITY))"
         errorLine2="                                                                                          ~~~~~~~~~~~~~~~~~~~">
         <location
-            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt"
-            line="132"
+            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt" line="137"
             column="91"/>
     </issue>
 
@@ -1808,8 +1902,7 @@
         errorLine1="        _columnsSets.put(&quot;load&quot;, TableInfo.Column(&quot;load&quot;, &quot;REAL&quot;, true, 0, null, TableInfo.CREATED_FROM_ENTITY))"
         errorLine2="                                           ~~~~~~">
         <location
-            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt"
-            line="133"
+            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt" line="138"
             column="44"/>
     </issue>
 
@@ -1819,8 +1912,7 @@
         errorLine1="        _columnsSets.put(&quot;load&quot;, TableInfo.Column(&quot;load&quot;, &quot;REAL&quot;, true, 0, null, TableInfo.CREATED_FROM_ENTITY))"
         errorLine2="                                                  ~~~~~~">
         <location
-            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt"
-            line="133"
+            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt" line="138"
             column="51"/>
     </issue>
 
@@ -1830,8 +1922,7 @@
         errorLine1="        _columnsSets.put(&quot;load&quot;, TableInfo.Column(&quot;load&quot;, &quot;REAL&quot;, true, 0, null, TableInfo.CREATED_FROM_ENTITY))"
         errorLine2="                                                          ~~~~~~">
         <location
-            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt"
-            line="133"
+            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt" line="138"
             column="59"/>
     </issue>
 
@@ -1841,8 +1932,7 @@
         errorLine1="        _columnsSets.put(&quot;load&quot;, TableInfo.Column(&quot;load&quot;, &quot;REAL&quot;, true, 0, null, TableInfo.CREATED_FROM_ENTITY))"
         errorLine2="                                                                           ~~~~">
         <location
-            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt"
-            line="133"
+            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt" line="138"
             column="76"/>
     </issue>
 
@@ -1852,8 +1942,7 @@
         errorLine1="        _columnsSets.put(&quot;load&quot;, TableInfo.Column(&quot;load&quot;, &quot;REAL&quot;, true, 0, null, TableInfo.CREATED_FROM_ENTITY))"
         errorLine2="                                                                                           ~~~~~~~~~~~~~~~~~~~">
         <location
-            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt"
-            line="133"
+            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt" line="138"
             column="92"/>
     </issue>
 
@@ -1863,8 +1952,7 @@
         errorLine1="        _columnsSets.put(&quot;reps&quot;, TableInfo.Column(&quot;reps&quot;, &quot;INTEGER&quot;, true, 0, null, TableInfo.CREATED_FROM_ENTITY))"
         errorLine2="                                           ~~~~~~">
         <location
-            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt"
-            line="134"
+            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt" line="139"
             column="44"/>
     </issue>
 
@@ -1874,8 +1962,7 @@
         errorLine1="        _columnsSets.put(&quot;reps&quot;, TableInfo.Column(&quot;reps&quot;, &quot;INTEGER&quot;, true, 0, null, TableInfo.CREATED_FROM_ENTITY))"
         errorLine2="                                                  ~~~~~~">
         <location
-            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt"
-            line="134"
+            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt" line="139"
             column="51"/>
     </issue>
 
@@ -1885,8 +1972,7 @@
         errorLine1="        _columnsSets.put(&quot;reps&quot;, TableInfo.Column(&quot;reps&quot;, &quot;INTEGER&quot;, true, 0, null, TableInfo.CREATED_FROM_ENTITY))"
         errorLine2="                                                          ~~~~~~~~~">
         <location
-            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt"
-            line="134"
+            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt" line="139"
             column="59"/>
     </issue>
 
@@ -1896,8 +1982,7 @@
         errorLine1="        _columnsSets.put(&quot;reps&quot;, TableInfo.Column(&quot;reps&quot;, &quot;INTEGER&quot;, true, 0, null, TableInfo.CREATED_FROM_ENTITY))"
         errorLine2="                                                                              ~~~~">
         <location
-            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt"
-            line="134"
+            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt" line="139"
             column="79"/>
     </issue>
 
@@ -1907,8 +1992,7 @@
         errorLine1="        _columnsSets.put(&quot;reps&quot;, TableInfo.Column(&quot;reps&quot;, &quot;INTEGER&quot;, true, 0, null, TableInfo.CREATED_FROM_ENTITY))"
         errorLine2="                                                                                              ~~~~~~~~~~~~~~~~~~~">
         <location
-            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt"
-            line="134"
+            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt" line="139"
             column="95"/>
     </issue>
 
@@ -1918,8 +2002,7 @@
         errorLine1="        _columnsSets.put(&quot;elapsedTime&quot;, TableInfo.Column(&quot;elapsedTime&quot;, &quot;INTEGER&quot;, true, 0, null, TableInfo.CREATED_FROM_ENTITY))"
         errorLine2="                                                  ~~~~~~">
         <location
-            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt"
-            line="135"
+            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt" line="140"
             column="51"/>
     </issue>
 
@@ -1929,8 +2012,7 @@
         errorLine1="        _columnsSets.put(&quot;elapsedTime&quot;, TableInfo.Column(&quot;elapsedTime&quot;, &quot;INTEGER&quot;, true, 0, null, TableInfo.CREATED_FROM_ENTITY))"
         errorLine2="                                                         ~~~~~~~~~~~~~">
         <location
-            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt"
-            line="135"
+            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt" line="140"
             column="58"/>
     </issue>
 
@@ -1940,8 +2022,7 @@
         errorLine1="        _columnsSets.put(&quot;elapsedTime&quot;, TableInfo.Column(&quot;elapsedTime&quot;, &quot;INTEGER&quot;, true, 0, null, TableInfo.CREATED_FROM_ENTITY))"
         errorLine2="                                                                        ~~~~~~~~~">
         <location
-            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt"
-            line="135"
+            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt" line="140"
             column="73"/>
     </issue>
 
@@ -1951,8 +2032,7 @@
         errorLine1="        _columnsSets.put(&quot;elapsedTime&quot;, TableInfo.Column(&quot;elapsedTime&quot;, &quot;INTEGER&quot;, true, 0, null, TableInfo.CREATED_FROM_ENTITY))"
         errorLine2="                                                                                            ~~~~">
         <location
-            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt"
-            line="135"
+            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt" line="140"
             column="93"/>
     </issue>
 
@@ -1962,8 +2042,7 @@
         errorLine1="        _columnsSets.put(&quot;elapsedTime&quot;, TableInfo.Column(&quot;elapsedTime&quot;, &quot;INTEGER&quot;, true, 0, null, TableInfo.CREATED_FROM_ENTITY))"
         errorLine2="                                                                                                            ~~~~~~~~~~~~~~~~~~~">
         <location
-            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt"
-            line="135"
+            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt" line="140"
             column="109"/>
     </issue>
 
@@ -1973,8 +2052,7 @@
         errorLine1="        _columnsSets.put(&quot;completed&quot;, TableInfo.Column(&quot;completed&quot;, &quot;INTEGER&quot;, true, 0, null, TableInfo.CREATED_FROM_ENTITY))"
         errorLine2="                                                ~~~~~~">
         <location
-            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt"
-            line="136"
+            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt" line="141"
             column="49"/>
     </issue>
 
@@ -1984,8 +2062,7 @@
         errorLine1="        _columnsSets.put(&quot;completed&quot;, TableInfo.Column(&quot;completed&quot;, &quot;INTEGER&quot;, true, 0, null, TableInfo.CREATED_FROM_ENTITY))"
         errorLine2="                                                       ~~~~~~~~~~~">
         <location
-            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt"
-            line="136"
+            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt" line="141"
             column="56"/>
     </issue>
 
@@ -1995,8 +2072,7 @@
         errorLine1="        _columnsSets.put(&quot;completed&quot;, TableInfo.Column(&quot;completed&quot;, &quot;INTEGER&quot;, true, 0, null, TableInfo.CREATED_FROM_ENTITY))"
         errorLine2="                                                                    ~~~~~~~~~">
         <location
-            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt"
-            line="136"
+            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt" line="141"
             column="69"/>
     </issue>
 
@@ -2006,8 +2082,7 @@
         errorLine1="        _columnsSets.put(&quot;completed&quot;, TableInfo.Column(&quot;completed&quot;, &quot;INTEGER&quot;, true, 0, null, TableInfo.CREATED_FROM_ENTITY))"
         errorLine2="                                                                                        ~~~~">
         <location
-            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt"
-            line="136"
+            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt" line="141"
             column="89"/>
     </issue>
 
@@ -2017,8 +2092,7 @@
         errorLine1="        _columnsSets.put(&quot;completed&quot;, TableInfo.Column(&quot;completed&quot;, &quot;INTEGER&quot;, true, 0, null, TableInfo.CREATED_FROM_ENTITY))"
         errorLine2="                                                                                                        ~~~~~~~~~~~~~~~~~~~">
         <location
-            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt"
-            line="136"
+            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt" line="141"
             column="105"/>
     </issue>
 
@@ -2028,8 +2102,7 @@
         errorLine1="        _columnsSets.put(&quot;exerciseId&quot;, TableInfo.Column(&quot;exerciseId&quot;, &quot;INTEGER&quot;, true, 0, null, TableInfo.CREATED_FROM_ENTITY))"
         errorLine2="                                                 ~~~~~~">
         <location
-            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt"
-            line="137"
+            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt" line="142"
             column="50"/>
     </issue>
 
@@ -2039,8 +2112,7 @@
         errorLine1="        _columnsSets.put(&quot;exerciseId&quot;, TableInfo.Column(&quot;exerciseId&quot;, &quot;INTEGER&quot;, true, 0, null, TableInfo.CREATED_FROM_ENTITY))"
         errorLine2="                                                        ~~~~~~~~~~~~">
         <location
-            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt"
-            line="137"
+            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt" line="142"
             column="57"/>
     </issue>
 
@@ -2050,8 +2122,7 @@
         errorLine1="        _columnsSets.put(&quot;exerciseId&quot;, TableInfo.Column(&quot;exerciseId&quot;, &quot;INTEGER&quot;, true, 0, null, TableInfo.CREATED_FROM_ENTITY))"
         errorLine2="                                                                      ~~~~~~~~~">
         <location
-            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt"
-            line="137"
+            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt" line="142"
             column="71"/>
     </issue>
 
@@ -2061,8 +2132,7 @@
         errorLine1="        _columnsSets.put(&quot;exerciseId&quot;, TableInfo.Column(&quot;exerciseId&quot;, &quot;INTEGER&quot;, true, 0, null, TableInfo.CREATED_FROM_ENTITY))"
         errorLine2="                                                                                          ~~~~">
         <location
-            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt"
-            line="137"
+            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt" line="142"
             column="91"/>
     </issue>
 
@@ -2072,8 +2142,7 @@
         errorLine1="        _columnsSets.put(&quot;exerciseId&quot;, TableInfo.Column(&quot;exerciseId&quot;, &quot;INTEGER&quot;, true, 0, null, TableInfo.CREATED_FROM_ENTITY))"
         errorLine2="                                                                                                          ~~~~~~~~~~~~~~~~~~~">
         <location
-            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt"
-            line="137"
+            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt" line="142"
             column="107"/>
     </issue>
 
@@ -2083,8 +2152,7 @@
         errorLine1="        val _foreignKeysSets: MutableSet&lt;TableInfo.ForeignKey> = mutableSetOf()"
         errorLine2="                                         ~~~~~~~~~~~~~~~~~~~~">
         <location
-            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt"
-            line="138"
+            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt" line="143"
             column="42"/>
     </issue>
 
@@ -2094,8 +2162,7 @@
         errorLine1="        _foreignKeysSets.add(TableInfo.ForeignKey(&quot;exercises&quot;, &quot;CASCADE&quot;, &quot;NO ACTION&quot;, listOf(&quot;exerciseId&quot;), listOf(&quot;id&quot;)))"
         errorLine2="                                       ~~~~~~~~~~">
         <location
-            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt"
-            line="139"
+            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt" line="144"
             column="40"/>
     </issue>
 
@@ -2105,8 +2172,7 @@
         errorLine1="        _foreignKeysSets.add(TableInfo.ForeignKey(&quot;exercises&quot;, &quot;CASCADE&quot;, &quot;NO ACTION&quot;, listOf(&quot;exerciseId&quot;), listOf(&quot;id&quot;)))"
         errorLine2="                                                  ~~~~~~~~~~~">
         <location
-            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt"
-            line="139"
+            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt" line="144"
             column="51"/>
     </issue>
 
@@ -2116,8 +2182,7 @@
         errorLine1="        _foreignKeysSets.add(TableInfo.ForeignKey(&quot;exercises&quot;, &quot;CASCADE&quot;, &quot;NO ACTION&quot;, listOf(&quot;exerciseId&quot;), listOf(&quot;id&quot;)))"
         errorLine2="                                                               ~~~~~~~~~">
         <location
-            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt"
-            line="139"
+            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt" line="144"
             column="64"/>
     </issue>
 
@@ -2127,8 +2192,7 @@
         errorLine1="        _foreignKeysSets.add(TableInfo.ForeignKey(&quot;exercises&quot;, &quot;CASCADE&quot;, &quot;NO ACTION&quot;, listOf(&quot;exerciseId&quot;), listOf(&quot;id&quot;)))"
         errorLine2="                                                                          ~~~~~~~~~~~">
         <location
-            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt"
-            line="139"
+            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt" line="144"
             column="75"/>
     </issue>
 
@@ -2138,8 +2202,7 @@
         errorLine1="        _foreignKeysSets.add(TableInfo.ForeignKey(&quot;exercises&quot;, &quot;CASCADE&quot;, &quot;NO ACTION&quot;, listOf(&quot;exerciseId&quot;), listOf(&quot;id&quot;)))"
         errorLine2="                                                                                       ~~~~~~">
         <location
-            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt"
-            line="139"
+            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt" line="144"
             column="88"/>
     </issue>
 
@@ -2149,8 +2212,7 @@
         errorLine1="        _foreignKeysSets.add(TableInfo.ForeignKey(&quot;exercises&quot;, &quot;CASCADE&quot;, &quot;NO ACTION&quot;, listOf(&quot;exerciseId&quot;), listOf(&quot;id&quot;)))"
         errorLine2="                                                                                                             ~~~~~~">
         <location
-            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt"
-            line="139"
+            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt" line="144"
             column="110"/>
     </issue>
 
@@ -2160,8 +2222,7 @@
         errorLine1="        val _indicesSets: MutableSet&lt;TableInfo.Index> = mutableSetOf()"
         errorLine2="                                     ~~~~~~~~~~~~~~~">
         <location
-            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt"
-            line="140"
+            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt" line="145"
             column="38"/>
     </issue>
 
@@ -2171,8 +2232,7 @@
         errorLine1="        _indicesSets.add(TableInfo.Index(&quot;index_sets_exerciseId&quot;, false, listOf(&quot;exerciseId&quot;), listOf(&quot;ASC&quot;)))"
         errorLine2="                                   ~~~~~">
         <location
-            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt"
-            line="141"
+            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt" line="146"
             column="36"/>
     </issue>
 
@@ -2182,8 +2242,7 @@
         errorLine1="        _indicesSets.add(TableInfo.Index(&quot;index_sets_exerciseId&quot;, false, listOf(&quot;exerciseId&quot;), listOf(&quot;ASC&quot;)))"
         errorLine2="                                         ~~~~~~~~~~~~~~~~~~~~~~~">
         <location
-            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt"
-            line="141"
+            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt" line="146"
             column="42"/>
     </issue>
 
@@ -2193,8 +2252,7 @@
         errorLine1="        _indicesSets.add(TableInfo.Index(&quot;index_sets_exerciseId&quot;, false, listOf(&quot;exerciseId&quot;), listOf(&quot;ASC&quot;)))"
         errorLine2="                                                                         ~~~~~~">
         <location
-            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt"
-            line="141"
+            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt" line="146"
             column="74"/>
     </issue>
 
@@ -2204,8 +2262,7 @@
         errorLine1="        _indicesSets.add(TableInfo.Index(&quot;index_sets_exerciseId&quot;, false, listOf(&quot;exerciseId&quot;), listOf(&quot;ASC&quot;)))"
         errorLine2="                                                                                               ~~~~~~">
         <location
-            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt"
-            line="141"
+            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt" line="146"
             column="96"/>
     </issue>
 
@@ -2215,8 +2272,7 @@
         errorLine1="        val _infoSets: TableInfo = TableInfo(&quot;sets&quot;, _columnsSets, _foreignKeysSets, _indicesSets)"
         errorLine2="                       ~~~~~~~~~">
         <location
-            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt"
-            line="142"
+            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt" line="147"
             column="24"/>
     </issue>
 
@@ -2226,8 +2282,7 @@
         errorLine1="        val _infoSets: TableInfo = TableInfo(&quot;sets&quot;, _columnsSets, _foreignKeysSets, _indicesSets)"
         errorLine2="                                   ~~~~~~~~~">
         <location
-            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt"
-            line="142"
+            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt" line="147"
             column="36"/>
     </issue>
 
@@ -2237,8 +2292,7 @@
         errorLine1="        val _infoSets: TableInfo = TableInfo(&quot;sets&quot;, _columnsSets, _foreignKeysSets, _indicesSets)"
         errorLine2="                                             ~~~~~~">
         <location
-            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt"
-            line="142"
+            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt" line="147"
             column="46"/>
     </issue>
 
@@ -2248,8 +2302,7 @@
         errorLine1="        val _infoSets: TableInfo = TableInfo(&quot;sets&quot;, _columnsSets, _foreignKeysSets, _indicesSets)"
         errorLine2="                                                     ~~~~~~~~~~~~">
         <location
-            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt"
-            line="142"
+            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt" line="147"
             column="54"/>
     </issue>
 
@@ -2259,8 +2312,7 @@
         errorLine1="        val _infoSets: TableInfo = TableInfo(&quot;sets&quot;, _columnsSets, _foreignKeysSets, _indicesSets)"
         errorLine2="                                                                   ~~~~~~~~~~~~~~~~">
         <location
-            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt"
-            line="142"
+            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt" line="147"
             column="68"/>
     </issue>
 
@@ -2270,8 +2322,7 @@
         errorLine1="        val _infoSets: TableInfo = TableInfo(&quot;sets&quot;, _columnsSets, _foreignKeysSets, _indicesSets)"
         errorLine2="                                                                                     ~~~~~~~~~~~~">
         <location
-            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt"
-            line="142"
+            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt" line="147"
             column="86"/>
     </issue>
 
@@ -2281,8 +2332,7 @@
         errorLine1="        val _existingSets: TableInfo = read(connection, &quot;sets&quot;)"
         errorLine2="                                       ~~~~">
         <location
-            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt"
-            line="143"
+            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt" line="148"
             column="40"/>
     </issue>
 
@@ -2292,8 +2342,7 @@
         errorLine1="        val _existingSets: TableInfo = read(connection, &quot;sets&quot;)"
         errorLine2="                                            ~~~~~~~~~~">
         <location
-            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt"
-            line="143"
+            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt" line="148"
             column="45"/>
     </issue>
 
@@ -2303,8 +2352,7 @@
         errorLine1="        val _existingSets: TableInfo = read(connection, &quot;sets&quot;)"
         errorLine2="                                                        ~~~~~~">
         <location
-            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt"
-            line="143"
+            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt" line="148"
             column="57"/>
     </issue>
 
@@ -2314,8 +2362,7 @@
         errorLine1="        val _existingSets: TableInfo = read(connection, &quot;sets&quot;)"
         errorLine2="                           ~~~~~~~~~">
         <location
-            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt"
-            line="143"
+            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt" line="148"
             column="28"/>
     </issue>
 
@@ -2325,8 +2372,7 @@
         errorLine1="        if (!_infoSets.equals(_existingSets)) {"
         errorLine2="                       ~~~~~~">
         <location
-            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt"
-            line="144"
+            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt" line="149"
             column="24"/>
     </issue>
 
@@ -2336,8 +2382,7 @@
         errorLine1="        if (!_infoSets.equals(_existingSets)) {"
         errorLine2="                              ~~~~~~~~~~~~~">
         <location
-            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt"
-            line="144"
+            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt" line="149"
             column="31"/>
     </issue>
 
@@ -2347,8 +2392,7 @@
         errorLine1="          return RoomOpenDelegate.ValidationResult(false, &quot;&quot;&quot;"
         errorLine2="                                  ~~~~~~~~~~~~~~~~">
         <location
-            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt"
-            line="145"
+            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt" line="150"
             column="35"/>
     </issue>
 
@@ -2358,8 +2402,7 @@
         errorLine1="          return RoomOpenDelegate.ValidationResult(false, &quot;&quot;&quot;"
         errorLine2="                                                          ^">
         <location
-            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt"
-            line="145"
+            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt" line="150"
             column="59"/>
     </issue>
 
@@ -2369,8 +2412,7 @@
         errorLine1="        val _columnsMeasurements: MutableMap&lt;String, TableInfo.Column> = mutableMapOf()"
         errorLine2="                                                     ~~~~~~~~~~~~~~~~">
         <location
-            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt"
-            line="153"
+            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt" line="158"
             column="54"/>
     </issue>
 
@@ -2380,8 +2422,7 @@
         errorLine1="        _columnsMeasurements.put(&quot;id&quot;, TableInfo.Column(&quot;id&quot;, &quot;INTEGER&quot;, true, 1, null, TableInfo.CREATED_FROM_ENTITY))"
         errorLine2="                                                 ~~~~~~">
         <location
-            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt"
-            line="154"
+            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt" line="159"
             column="50"/>
     </issue>
 
@@ -2391,8 +2432,7 @@
         errorLine1="        _columnsMeasurements.put(&quot;id&quot;, TableInfo.Column(&quot;id&quot;, &quot;INTEGER&quot;, true, 1, null, TableInfo.CREATED_FROM_ENTITY))"
         errorLine2="                                                        ~~~~">
         <location
-            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt"
-            line="154"
+            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt" line="159"
             column="57"/>
     </issue>
 
@@ -2402,8 +2442,7 @@
         errorLine1="        _columnsMeasurements.put(&quot;id&quot;, TableInfo.Column(&quot;id&quot;, &quot;INTEGER&quot;, true, 1, null, TableInfo.CREATED_FROM_ENTITY))"
         errorLine2="                                                              ~~~~~~~~~">
         <location
-            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt"
-            line="154"
+            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt" line="159"
             column="63"/>
     </issue>
 
@@ -2413,8 +2452,7 @@
         errorLine1="        _columnsMeasurements.put(&quot;id&quot;, TableInfo.Column(&quot;id&quot;, &quot;INTEGER&quot;, true, 1, null, TableInfo.CREATED_FROM_ENTITY))"
         errorLine2="                                                                                  ~~~~">
         <location
-            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt"
-            line="154"
+            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt" line="159"
             column="83"/>
     </issue>
 
@@ -2424,8 +2462,7 @@
         errorLine1="        _columnsMeasurements.put(&quot;id&quot;, TableInfo.Column(&quot;id&quot;, &quot;INTEGER&quot;, true, 1, null, TableInfo.CREATED_FROM_ENTITY))"
         errorLine2="                                                                                                  ~~~~~~~~~~~~~~~~~~~">
         <location
-            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt"
-            line="154"
+            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt" line="159"
             column="99"/>
     </issue>
 
@@ -2435,8 +2472,7 @@
         errorLine1="        _columnsMeasurements.put(&quot;bodyWeight&quot;, TableInfo.Column(&quot;bodyWeight&quot;, &quot;REAL&quot;, true, 0, null, TableInfo.CREATED_FROM_ENTITY))"
         errorLine2="                                                         ~~~~~~">
         <location
-            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt"
-            line="155"
+            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt" line="160"
             column="58"/>
     </issue>
 
@@ -2446,8 +2482,7 @@
         errorLine1="        _columnsMeasurements.put(&quot;bodyWeight&quot;, TableInfo.Column(&quot;bodyWeight&quot;, &quot;REAL&quot;, true, 0, null, TableInfo.CREATED_FROM_ENTITY))"
         errorLine2="                                                                ~~~~~~~~~~~~">
         <location
-            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt"
-            line="155"
+            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt" line="160"
             column="65"/>
     </issue>
 
@@ -2457,8 +2492,7 @@
         errorLine1="        _columnsMeasurements.put(&quot;bodyWeight&quot;, TableInfo.Column(&quot;bodyWeight&quot;, &quot;REAL&quot;, true, 0, null, TableInfo.CREATED_FROM_ENTITY))"
         errorLine2="                                                                              ~~~~~~">
         <location
-            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt"
-            line="155"
+            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt" line="160"
             column="79"/>
     </issue>
 
@@ -2468,8 +2502,7 @@
         errorLine1="        _columnsMeasurements.put(&quot;bodyWeight&quot;, TableInfo.Column(&quot;bodyWeight&quot;, &quot;REAL&quot;, true, 0, null, TableInfo.CREATED_FROM_ENTITY))"
         errorLine2="                                                                                               ~~~~">
         <location
-            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt"
-            line="155"
+            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt" line="160"
             column="96"/>
     </issue>
 
@@ -2479,8 +2512,7 @@
         errorLine1="        _columnsMeasurements.put(&quot;bodyWeight&quot;, TableInfo.Column(&quot;bodyWeight&quot;, &quot;REAL&quot;, true, 0, null, TableInfo.CREATED_FROM_ENTITY))"
         errorLine2="                                                                                                               ~~~~~~~~~~~~~~~~~~~">
         <location
-            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt"
-            line="155"
+            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt" line="160"
             column="112"/>
     </issue>
 
@@ -2490,8 +2522,7 @@
         errorLine1="        _columnsMeasurements.put(&quot;bodyFatPercentage&quot;, TableInfo.Column(&quot;bodyFatPercentage&quot;, &quot;INTEGER&quot;, true, 0, null, TableInfo.CREATED_FROM_ENTITY))"
         errorLine2="                                                                ~~~~~~">
         <location
-            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt"
-            line="156"
+            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt" line="161"
             column="65"/>
     </issue>
 
@@ -2501,8 +2532,7 @@
         errorLine1="        _columnsMeasurements.put(&quot;bodyFatPercentage&quot;, TableInfo.Column(&quot;bodyFatPercentage&quot;, &quot;INTEGER&quot;, true, 0, null, TableInfo.CREATED_FROM_ENTITY))"
         errorLine2="                                                                       ~~~~~~~~~~~~~~~~~~~">
         <location
-            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt"
-            line="156"
+            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt" line="161"
             column="72"/>
     </issue>
 
@@ -2512,8 +2542,7 @@
         errorLine1="        _columnsMeasurements.put(&quot;bodyFatPercentage&quot;, TableInfo.Column(&quot;bodyFatPercentage&quot;, &quot;INTEGER&quot;, true, 0, null, TableInfo.CREATED_FROM_ENTITY))"
         errorLine2="                                                                                            ~~~~~~~~~">
         <location
-            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt"
-            line="156"
+            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt" line="161"
             column="93"/>
     </issue>
 
@@ -2523,8 +2552,7 @@
         errorLine1="        _columnsMeasurements.put(&quot;bodyFatPercentage&quot;, TableInfo.Column(&quot;bodyFatPercentage&quot;, &quot;INTEGER&quot;, true, 0, null, TableInfo.CREATED_FROM_ENTITY))"
         errorLine2="                                                                                                                ~~~~">
         <location
-            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt"
-            line="156"
+            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt" line="161"
             column="113"/>
     </issue>
 
@@ -2534,8 +2562,7 @@
         errorLine1="        _columnsMeasurements.put(&quot;bodyFatPercentage&quot;, TableInfo.Column(&quot;bodyFatPercentage&quot;, &quot;INTEGER&quot;, true, 0, null, TableInfo.CREATED_FROM_ENTITY))"
         errorLine2="                                                                                                                                ~~~~~~~~~~~~~~~~~~~">
         <location
-            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt"
-            line="156"
+            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt" line="161"
             column="129"/>
     </issue>
 
@@ -2545,8 +2572,7 @@
         errorLine1="        _columnsMeasurements.put(&quot;muscleMassPercentage&quot;, TableInfo.Column(&quot;muscleMassPercentage&quot;, &quot;INTEGER&quot;, true, 0, null, TableInfo.CREATED_FROM_ENTITY))"
         errorLine2="                                                                   ~~~~~~">
         <location
-            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt"
-            line="157"
+            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt" line="162"
             column="68"/>
     </issue>
 
@@ -2556,8 +2582,7 @@
         errorLine1="        _columnsMeasurements.put(&quot;muscleMassPercentage&quot;, TableInfo.Column(&quot;muscleMassPercentage&quot;, &quot;INTEGER&quot;, true, 0, null, TableInfo.CREATED_FROM_ENTITY))"
         errorLine2="                                                                          ~~~~~~~~~~~~~~~~~~~~~~">
         <location
-            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt"
-            line="157"
+            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt" line="162"
             column="75"/>
     </issue>
 
@@ -2567,8 +2592,7 @@
         errorLine1="        _columnsMeasurements.put(&quot;muscleMassPercentage&quot;, TableInfo.Column(&quot;muscleMassPercentage&quot;, &quot;INTEGER&quot;, true, 0, null, TableInfo.CREATED_FROM_ENTITY))"
         errorLine2="                                                                                                  ~~~~~~~~~">
         <location
-            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt"
-            line="157"
+            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt" line="162"
             column="99"/>
     </issue>
 
@@ -2578,8 +2602,7 @@
         errorLine1="        _columnsMeasurements.put(&quot;muscleMassPercentage&quot;, TableInfo.Column(&quot;muscleMassPercentage&quot;, &quot;INTEGER&quot;, true, 0, null, TableInfo.CREATED_FROM_ENTITY))"
         errorLine2="                                                                                                                      ~~~~">
         <location
-            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt"
-            line="157"
+            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt" line="162"
             column="119"/>
     </issue>
 
@@ -2589,8 +2612,7 @@
         errorLine1="        _columnsMeasurements.put(&quot;muscleMassPercentage&quot;, TableInfo.Column(&quot;muscleMassPercentage&quot;, &quot;INTEGER&quot;, true, 0, null, TableInfo.CREATED_FROM_ENTITY))"
         errorLine2="                                                                                                                                      ~~~~~~~~~~~~~~~~~~~">
         <location
-            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt"
-            line="157"
+            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt" line="162"
             column="135"/>
     </issue>
 
@@ -2600,8 +2622,7 @@
         errorLine1="        _columnsMeasurements.put(&quot;date&quot;, TableInfo.Column(&quot;date&quot;, &quot;TEXT&quot;, true, 0, null, TableInfo.CREATED_FROM_ENTITY))"
         errorLine2="                                                   ~~~~~~">
         <location
-            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt"
-            line="158"
+            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt" line="163"
             column="52"/>
     </issue>
 
@@ -2611,8 +2632,7 @@
         errorLine1="        _columnsMeasurements.put(&quot;date&quot;, TableInfo.Column(&quot;date&quot;, &quot;TEXT&quot;, true, 0, null, TableInfo.CREATED_FROM_ENTITY))"
         errorLine2="                                                          ~~~~~~">
         <location
-            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt"
-            line="158"
+            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt" line="163"
             column="59"/>
     </issue>
 
@@ -2622,8 +2642,7 @@
         errorLine1="        _columnsMeasurements.put(&quot;date&quot;, TableInfo.Column(&quot;date&quot;, &quot;TEXT&quot;, true, 0, null, TableInfo.CREATED_FROM_ENTITY))"
         errorLine2="                                                                  ~~~~~~">
         <location
-            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt"
-            line="158"
+            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt" line="163"
             column="67"/>
     </issue>
 
@@ -2633,8 +2652,7 @@
         errorLine1="        _columnsMeasurements.put(&quot;date&quot;, TableInfo.Column(&quot;date&quot;, &quot;TEXT&quot;, true, 0, null, TableInfo.CREATED_FROM_ENTITY))"
         errorLine2="                                                                                   ~~~~">
         <location
-            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt"
-            line="158"
+            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt" line="163"
             column="84"/>
     </issue>
 
@@ -2644,8 +2662,7 @@
         errorLine1="        _columnsMeasurements.put(&quot;date&quot;, TableInfo.Column(&quot;date&quot;, &quot;TEXT&quot;, true, 0, null, TableInfo.CREATED_FROM_ENTITY))"
         errorLine2="                                                                                                   ~~~~~~~~~~~~~~~~~~~">
         <location
-            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt"
-            line="158"
+            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt" line="163"
             column="100"/>
     </issue>
 
@@ -2655,8 +2672,7 @@
         errorLine1="        _columnsMeasurements.put(&quot;notes&quot;, TableInfo.Column(&quot;notes&quot;, &quot;TEXT&quot;, true, 0, null, TableInfo.CREATED_FROM_ENTITY))"
         errorLine2="                                                    ~~~~~~">
         <location
-            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt"
-            line="159"
+            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt" line="164"
             column="53"/>
     </issue>
 
@@ -2666,8 +2682,7 @@
         errorLine1="        _columnsMeasurements.put(&quot;notes&quot;, TableInfo.Column(&quot;notes&quot;, &quot;TEXT&quot;, true, 0, null, TableInfo.CREATED_FROM_ENTITY))"
         errorLine2="                                                           ~~~~~~~">
         <location
-            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt"
-            line="159"
+            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt" line="164"
             column="60"/>
     </issue>
 
@@ -2677,8 +2692,7 @@
         errorLine1="        _columnsMeasurements.put(&quot;notes&quot;, TableInfo.Column(&quot;notes&quot;, &quot;TEXT&quot;, true, 0, null, TableInfo.CREATED_FROM_ENTITY))"
         errorLine2="                                                                    ~~~~~~">
         <location
-            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt"
-            line="159"
+            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt" line="164"
             column="69"/>
     </issue>
 
@@ -2688,8 +2702,7 @@
         errorLine1="        _columnsMeasurements.put(&quot;notes&quot;, TableInfo.Column(&quot;notes&quot;, &quot;TEXT&quot;, true, 0, null, TableInfo.CREATED_FROM_ENTITY))"
         errorLine2="                                                                                     ~~~~">
         <location
-            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt"
-            line="159"
+            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt" line="164"
             column="86"/>
     </issue>
 
@@ -2699,8 +2712,7 @@
         errorLine1="        _columnsMeasurements.put(&quot;notes&quot;, TableInfo.Column(&quot;notes&quot;, &quot;TEXT&quot;, true, 0, null, TableInfo.CREATED_FROM_ENTITY))"
         errorLine2="                                                                                                     ~~~~~~~~~~~~~~~~~~~">
         <location
-            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt"
-            line="159"
+            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt" line="164"
             column="102"/>
     </issue>
 
@@ -2710,8 +2722,7 @@
         errorLine1="        val _foreignKeysMeasurements: MutableSet&lt;TableInfo.ForeignKey> = mutableSetOf()"
         errorLine2="                                                 ~~~~~~~~~~~~~~~~~~~~">
         <location
-            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt"
-            line="160"
+            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt" line="165"
             column="50"/>
     </issue>
 
@@ -2721,8 +2732,7 @@
         errorLine1="        val _indicesMeasurements: MutableSet&lt;TableInfo.Index> = mutableSetOf()"
         errorLine2="                                             ~~~~~~~~~~~~~~~">
         <location
-            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt"
-            line="161"
+            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt" line="166"
             column="46"/>
     </issue>
 
@@ -2732,8 +2742,7 @@
         errorLine1="        val _infoMeasurements: TableInfo = TableInfo(&quot;measurements&quot;, _columnsMeasurements, _foreignKeysMeasurements, _indicesMeasurements)"
         errorLine2="                               ~~~~~~~~~">
         <location
-            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt"
-            line="162"
+            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt" line="167"
             column="32"/>
     </issue>
 
@@ -2743,8 +2752,7 @@
         errorLine1="        val _infoMeasurements: TableInfo = TableInfo(&quot;measurements&quot;, _columnsMeasurements, _foreignKeysMeasurements, _indicesMeasurements)"
         errorLine2="                                           ~~~~~~~~~">
         <location
-            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt"
-            line="162"
+            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt" line="167"
             column="44"/>
     </issue>
 
@@ -2754,8 +2762,7 @@
         errorLine1="        val _infoMeasurements: TableInfo = TableInfo(&quot;measurements&quot;, _columnsMeasurements, _foreignKeysMeasurements, _indicesMeasurements)"
         errorLine2="                                                     ~~~~~~~~~~~~~~">
         <location
-            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt"
-            line="162"
+            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt" line="167"
             column="54"/>
     </issue>
 
@@ -2765,8 +2772,7 @@
         errorLine1="        val _infoMeasurements: TableInfo = TableInfo(&quot;measurements&quot;, _columnsMeasurements, _foreignKeysMeasurements, _indicesMeasurements)"
         errorLine2="                                                                     ~~~~~~~~~~~~~~~~~~~~">
         <location
-            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt"
-            line="162"
+            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt" line="167"
             column="70"/>
     </issue>
 
@@ -2776,8 +2782,7 @@
         errorLine1="        val _infoMeasurements: TableInfo = TableInfo(&quot;measurements&quot;, _columnsMeasurements, _foreignKeysMeasurements, _indicesMeasurements)"
         errorLine2="                                                                                           ~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
-            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt"
-            line="162"
+            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt" line="167"
             column="92"/>
     </issue>
 
@@ -2787,8 +2792,7 @@
         errorLine1="        val _infoMeasurements: TableInfo = TableInfo(&quot;measurements&quot;, _columnsMeasurements, _foreignKeysMeasurements, _indicesMeasurements)"
         errorLine2="                                                                                                                     ~~~~~~~~~~~~~~~~~~~~">
         <location
-            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt"
-            line="162"
+            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt" line="167"
             column="118"/>
     </issue>
 
@@ -2798,8 +2802,7 @@
         errorLine1="        val _existingMeasurements: TableInfo = read(connection, &quot;measurements&quot;)"
         errorLine2="                                               ~~~~">
         <location
-            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt"
-            line="163"
+            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt" line="168"
             column="48"/>
     </issue>
 
@@ -2809,8 +2812,7 @@
         errorLine1="        val _existingMeasurements: TableInfo = read(connection, &quot;measurements&quot;)"
         errorLine2="                                                    ~~~~~~~~~~">
         <location
-            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt"
-            line="163"
+            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt" line="168"
             column="53"/>
     </issue>
 
@@ -2820,8 +2822,7 @@
         errorLine1="        val _existingMeasurements: TableInfo = read(connection, &quot;measurements&quot;)"
         errorLine2="                                                                ~~~~~~~~~~~~~~">
         <location
-            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt"
-            line="163"
+            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt" line="168"
             column="65"/>
     </issue>
 
@@ -2831,8 +2832,7 @@
         errorLine1="        val _existingMeasurements: TableInfo = read(connection, &quot;measurements&quot;)"
         errorLine2="                                   ~~~~~~~~~">
         <location
-            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt"
-            line="163"
+            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt" line="168"
             column="36"/>
     </issue>
 
@@ -2842,8 +2842,7 @@
         errorLine1="        if (!_infoMeasurements.equals(_existingMeasurements)) {"
         errorLine2="                               ~~~~~~">
         <location
-            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt"
-            line="164"
+            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt" line="169"
             column="32"/>
     </issue>
 
@@ -2853,8 +2852,7 @@
         errorLine1="        if (!_infoMeasurements.equals(_existingMeasurements)) {"
         errorLine2="                                      ~~~~~~~~~~~~~~~~~~~~~">
         <location
-            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt"
-            line="164"
+            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt" line="169"
             column="39"/>
     </issue>
 
@@ -2864,8 +2862,7 @@
         errorLine1="          return RoomOpenDelegate.ValidationResult(false, &quot;&quot;&quot;"
         errorLine2="                                  ~~~~~~~~~~~~~~~~">
         <location
-            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt"
-            line="165"
+            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt" line="170"
             column="35"/>
     </issue>
 
@@ -2875,8 +2872,7 @@
         errorLine1="          return RoomOpenDelegate.ValidationResult(false, &quot;&quot;&quot;"
         errorLine2="                                                          ^">
         <location
-            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt"
-            line="165"
+            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt" line="170"
             column="59"/>
     </issue>
 
@@ -2886,8 +2882,7 @@
         errorLine1="        val _columnsDataset: MutableMap&lt;String, TableInfo.Column> = mutableMapOf()"
         errorLine2="                                                ~~~~~~~~~~~~~~~~">
         <location
-            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt"
-            line="173"
+            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt" line="178"
             column="49"/>
     </issue>
 
@@ -2897,8 +2892,7 @@
         errorLine1="        _columnsDataset.put(&quot;id&quot;, TableInfo.Column(&quot;id&quot;, &quot;TEXT&quot;, true, 1, null, TableInfo.CREATED_FROM_ENTITY))"
         errorLine2="                                            ~~~~~~">
         <location
-            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt"
-            line="174"
+            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt" line="179"
             column="45"/>
     </issue>
 
@@ -2908,8 +2902,7 @@
         errorLine1="        _columnsDataset.put(&quot;id&quot;, TableInfo.Column(&quot;id&quot;, &quot;TEXT&quot;, true, 1, null, TableInfo.CREATED_FROM_ENTITY))"
         errorLine2="                                                   ~~~~">
         <location
-            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt"
-            line="174"
+            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt" line="179"
             column="52"/>
     </issue>
 
@@ -2919,8 +2912,7 @@
         errorLine1="        _columnsDataset.put(&quot;id&quot;, TableInfo.Column(&quot;id&quot;, &quot;TEXT&quot;, true, 1, null, TableInfo.CREATED_FROM_ENTITY))"
         errorLine2="                                                         ~~~~~~">
         <location
-            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt"
-            line="174"
+            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt" line="179"
             column="58"/>
     </issue>
 
@@ -2930,8 +2922,7 @@
         errorLine1="        _columnsDataset.put(&quot;id&quot;, TableInfo.Column(&quot;id&quot;, &quot;TEXT&quot;, true, 1, null, TableInfo.CREATED_FROM_ENTITY))"
         errorLine2="                                                                          ~~~~">
         <location
-            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt"
-            line="174"
+            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt" line="179"
             column="75"/>
     </issue>
 
@@ -2941,8 +2932,7 @@
         errorLine1="        _columnsDataset.put(&quot;id&quot;, TableInfo.Column(&quot;id&quot;, &quot;TEXT&quot;, true, 1, null, TableInfo.CREATED_FROM_ENTITY))"
         errorLine2="                                                                                          ~~~~~~~~~~~~~~~~~~~">
         <location
-            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt"
-            line="174"
+            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt" line="179"
             column="91"/>
     </issue>
 
@@ -2952,8 +2942,7 @@
         errorLine1="        _columnsDataset.put(&quot;name&quot;, TableInfo.Column(&quot;name&quot;, &quot;TEXT&quot;, true, 0, null, TableInfo.CREATED_FROM_ENTITY))"
         errorLine2="                                              ~~~~~~">
         <location
-            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt"
-            line="175"
+            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt" line="180"
             column="47"/>
     </issue>
 
@@ -2963,8 +2952,7 @@
         errorLine1="        _columnsDataset.put(&quot;name&quot;, TableInfo.Column(&quot;name&quot;, &quot;TEXT&quot;, true, 0, null, TableInfo.CREATED_FROM_ENTITY))"
         errorLine2="                                                     ~~~~~~">
         <location
-            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt"
-            line="175"
+            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt" line="180"
             column="54"/>
     </issue>
 
@@ -2974,8 +2962,7 @@
         errorLine1="        _columnsDataset.put(&quot;name&quot;, TableInfo.Column(&quot;name&quot;, &quot;TEXT&quot;, true, 0, null, TableInfo.CREATED_FROM_ENTITY))"
         errorLine2="                                                             ~~~~~~">
         <location
-            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt"
-            line="175"
+            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt" line="180"
             column="62"/>
     </issue>
 
@@ -2985,8 +2972,7 @@
         errorLine1="        _columnsDataset.put(&quot;name&quot;, TableInfo.Column(&quot;name&quot;, &quot;TEXT&quot;, true, 0, null, TableInfo.CREATED_FROM_ENTITY))"
         errorLine2="                                                                              ~~~~">
         <location
-            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt"
-            line="175"
+            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt" line="180"
             column="79"/>
     </issue>
 
@@ -2996,8 +2982,7 @@
         errorLine1="        _columnsDataset.put(&quot;name&quot;, TableInfo.Column(&quot;name&quot;, &quot;TEXT&quot;, true, 0, null, TableInfo.CREATED_FROM_ENTITY))"
         errorLine2="                                                                                              ~~~~~~~~~~~~~~~~~~~">
         <location
-            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt"
-            line="175"
+            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt" line="180"
             column="95"/>
     </issue>
 
@@ -3007,8 +2992,7 @@
         errorLine1="        _columnsDataset.put(&quot;force&quot;, TableInfo.Column(&quot;force&quot;, &quot;TEXT&quot;, false, 0, null, TableInfo.CREATED_FROM_ENTITY))"
         errorLine2="                                               ~~~~~~">
         <location
-            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt"
-            line="176"
+            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt" line="181"
             column="48"/>
     </issue>
 
@@ -3018,8 +3002,7 @@
         errorLine1="        _columnsDataset.put(&quot;force&quot;, TableInfo.Column(&quot;force&quot;, &quot;TEXT&quot;, false, 0, null, TableInfo.CREATED_FROM_ENTITY))"
         errorLine2="                                                      ~~~~~~~">
         <location
-            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt"
-            line="176"
+            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt" line="181"
             column="55"/>
     </issue>
 
@@ -3029,8 +3012,7 @@
         errorLine1="        _columnsDataset.put(&quot;force&quot;, TableInfo.Column(&quot;force&quot;, &quot;TEXT&quot;, false, 0, null, TableInfo.CREATED_FROM_ENTITY))"
         errorLine2="                                                               ~~~~~~">
         <location
-            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt"
-            line="176"
+            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt" line="181"
             column="64"/>
     </issue>
 
@@ -3040,8 +3022,7 @@
         errorLine1="        _columnsDataset.put(&quot;force&quot;, TableInfo.Column(&quot;force&quot;, &quot;TEXT&quot;, false, 0, null, TableInfo.CREATED_FROM_ENTITY))"
         errorLine2="                                                                                 ~~~~">
         <location
-            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt"
-            line="176"
+            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt" line="181"
             column="82"/>
     </issue>
 
@@ -3051,8 +3032,7 @@
         errorLine1="        _columnsDataset.put(&quot;force&quot;, TableInfo.Column(&quot;force&quot;, &quot;TEXT&quot;, false, 0, null, TableInfo.CREATED_FROM_ENTITY))"
         errorLine2="                                                                                                 ~~~~~~~~~~~~~~~~~~~">
         <location
-            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt"
-            line="176"
+            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt" line="181"
             column="98"/>
     </issue>
 
@@ -3062,8 +3042,7 @@
         errorLine1="        _columnsDataset.put(&quot;level&quot;, TableInfo.Column(&quot;level&quot;, &quot;TEXT&quot;, true, 0, null, TableInfo.CREATED_FROM_ENTITY))"
         errorLine2="                                               ~~~~~~">
         <location
-            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt"
-            line="177"
+            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt" line="182"
             column="48"/>
     </issue>
 
@@ -3073,8 +3052,7 @@
         errorLine1="        _columnsDataset.put(&quot;level&quot;, TableInfo.Column(&quot;level&quot;, &quot;TEXT&quot;, true, 0, null, TableInfo.CREATED_FROM_ENTITY))"
         errorLine2="                                                      ~~~~~~~">
         <location
-            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt"
-            line="177"
+            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt" line="182"
             column="55"/>
     </issue>
 
@@ -3084,8 +3062,7 @@
         errorLine1="        _columnsDataset.put(&quot;level&quot;, TableInfo.Column(&quot;level&quot;, &quot;TEXT&quot;, true, 0, null, TableInfo.CREATED_FROM_ENTITY))"
         errorLine2="                                                               ~~~~~~">
         <location
-            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt"
-            line="177"
+            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt" line="182"
             column="64"/>
     </issue>
 
@@ -3095,8 +3072,7 @@
         errorLine1="        _columnsDataset.put(&quot;level&quot;, TableInfo.Column(&quot;level&quot;, &quot;TEXT&quot;, true, 0, null, TableInfo.CREATED_FROM_ENTITY))"
         errorLine2="                                                                                ~~~~">
         <location
-            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt"
-            line="177"
+            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt" line="182"
             column="81"/>
     </issue>
 
@@ -3106,8 +3082,7 @@
         errorLine1="        _columnsDataset.put(&quot;level&quot;, TableInfo.Column(&quot;level&quot;, &quot;TEXT&quot;, true, 0, null, TableInfo.CREATED_FROM_ENTITY))"
         errorLine2="                                                                                                ~~~~~~~~~~~~~~~~~~~">
         <location
-            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt"
-            line="177"
+            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt" line="182"
             column="97"/>
     </issue>
 
@@ -3117,8 +3092,7 @@
         errorLine1="        _columnsDataset.put(&quot;mechanic&quot;, TableInfo.Column(&quot;mechanic&quot;, &quot;TEXT&quot;, false, 0, null, TableInfo.CREATED_FROM_ENTITY))"
         errorLine2="                                                  ~~~~~~">
         <location
-            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt"
-            line="178"
+            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt" line="183"
             column="51"/>
     </issue>
 
@@ -3128,8 +3102,7 @@
         errorLine1="        _columnsDataset.put(&quot;mechanic&quot;, TableInfo.Column(&quot;mechanic&quot;, &quot;TEXT&quot;, false, 0, null, TableInfo.CREATED_FROM_ENTITY))"
         errorLine2="                                                         ~~~~~~~~~~">
         <location
-            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt"
-            line="178"
+            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt" line="183"
             column="58"/>
     </issue>
 
@@ -3139,8 +3112,7 @@
         errorLine1="        _columnsDataset.put(&quot;mechanic&quot;, TableInfo.Column(&quot;mechanic&quot;, &quot;TEXT&quot;, false, 0, null, TableInfo.CREATED_FROM_ENTITY))"
         errorLine2="                                                                     ~~~~~~">
         <location
-            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt"
-            line="178"
+            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt" line="183"
             column="70"/>
     </issue>
 
@@ -3150,8 +3122,7 @@
         errorLine1="        _columnsDataset.put(&quot;mechanic&quot;, TableInfo.Column(&quot;mechanic&quot;, &quot;TEXT&quot;, false, 0, null, TableInfo.CREATED_FROM_ENTITY))"
         errorLine2="                                                                                       ~~~~">
         <location
-            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt"
-            line="178"
+            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt" line="183"
             column="88"/>
     </issue>
 
@@ -3161,8 +3132,7 @@
         errorLine1="        _columnsDataset.put(&quot;mechanic&quot;, TableInfo.Column(&quot;mechanic&quot;, &quot;TEXT&quot;, false, 0, null, TableInfo.CREATED_FROM_ENTITY))"
         errorLine2="                                                                                                       ~~~~~~~~~~~~~~~~~~~">
         <location
-            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt"
-            line="178"
+            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt" line="183"
             column="104"/>
     </issue>
 
@@ -3172,8 +3142,7 @@
         errorLine1="        _columnsDataset.put(&quot;equipment&quot;, TableInfo.Column(&quot;equipment&quot;, &quot;TEXT&quot;, false, 0, null, TableInfo.CREATED_FROM_ENTITY))"
         errorLine2="                                                   ~~~~~~">
         <location
-            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt"
-            line="179"
+            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt" line="184"
             column="52"/>
     </issue>
 
@@ -3183,8 +3152,7 @@
         errorLine1="        _columnsDataset.put(&quot;equipment&quot;, TableInfo.Column(&quot;equipment&quot;, &quot;TEXT&quot;, false, 0, null, TableInfo.CREATED_FROM_ENTITY))"
         errorLine2="                                                          ~~~~~~~~~~~">
         <location
-            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt"
-            line="179"
+            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt" line="184"
             column="59"/>
     </issue>
 
@@ -3194,8 +3162,7 @@
         errorLine1="        _columnsDataset.put(&quot;equipment&quot;, TableInfo.Column(&quot;equipment&quot;, &quot;TEXT&quot;, false, 0, null, TableInfo.CREATED_FROM_ENTITY))"
         errorLine2="                                                                       ~~~~~~">
         <location
-            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt"
-            line="179"
+            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt" line="184"
             column="72"/>
     </issue>
 
@@ -3205,8 +3172,7 @@
         errorLine1="        _columnsDataset.put(&quot;equipment&quot;, TableInfo.Column(&quot;equipment&quot;, &quot;TEXT&quot;, false, 0, null, TableInfo.CREATED_FROM_ENTITY))"
         errorLine2="                                                                                         ~~~~">
         <location
-            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt"
-            line="179"
+            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt" line="184"
             column="90"/>
     </issue>
 
@@ -3216,8 +3182,7 @@
         errorLine1="        _columnsDataset.put(&quot;equipment&quot;, TableInfo.Column(&quot;equipment&quot;, &quot;TEXT&quot;, false, 0, null, TableInfo.CREATED_FROM_ENTITY))"
         errorLine2="                                                                                                         ~~~~~~~~~~~~~~~~~~~">
         <location
-            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt"
-            line="179"
+            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt" line="184"
             column="106"/>
     </issue>
 
@@ -3227,8 +3192,7 @@
         errorLine1="        _columnsDataset.put(&quot;primaryMuscles&quot;, TableInfo.Column(&quot;primaryMuscles&quot;, &quot;TEXT&quot;, true, 0, null, TableInfo.CREATED_FROM_ENTITY))"
         errorLine2="                                                        ~~~~~~">
         <location
-            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt"
-            line="180"
+            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt" line="185"
             column="57"/>
     </issue>
 
@@ -3238,8 +3202,7 @@
         errorLine1="        _columnsDataset.put(&quot;primaryMuscles&quot;, TableInfo.Column(&quot;primaryMuscles&quot;, &quot;TEXT&quot;, true, 0, null, TableInfo.CREATED_FROM_ENTITY))"
         errorLine2="                                                               ~~~~~~~~~~~~~~~~">
         <location
-            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt"
-            line="180"
+            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt" line="185"
             column="64"/>
     </issue>
 
@@ -3249,8 +3212,7 @@
         errorLine1="        _columnsDataset.put(&quot;primaryMuscles&quot;, TableInfo.Column(&quot;primaryMuscles&quot;, &quot;TEXT&quot;, true, 0, null, TableInfo.CREATED_FROM_ENTITY))"
         errorLine2="                                                                                 ~~~~~~">
         <location
-            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt"
-            line="180"
+            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt" line="185"
             column="82"/>
     </issue>
 
@@ -3260,8 +3222,7 @@
         errorLine1="        _columnsDataset.put(&quot;primaryMuscles&quot;, TableInfo.Column(&quot;primaryMuscles&quot;, &quot;TEXT&quot;, true, 0, null, TableInfo.CREATED_FROM_ENTITY))"
         errorLine2="                                                                                                  ~~~~">
         <location
-            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt"
-            line="180"
+            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt" line="185"
             column="99"/>
     </issue>
 
@@ -3271,8 +3232,7 @@
         errorLine1="        _columnsDataset.put(&quot;primaryMuscles&quot;, TableInfo.Column(&quot;primaryMuscles&quot;, &quot;TEXT&quot;, true, 0, null, TableInfo.CREATED_FROM_ENTITY))"
         errorLine2="                                                                                                                  ~~~~~~~~~~~~~~~~~~~">
         <location
-            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt"
-            line="180"
+            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt" line="185"
             column="115"/>
     </issue>
 
@@ -3282,8 +3242,7 @@
         errorLine1="        _columnsDataset.put(&quot;secondaryMuscles&quot;, TableInfo.Column(&quot;secondaryMuscles&quot;, &quot;TEXT&quot;, true, 0, null, TableInfo.CREATED_FROM_ENTITY))"
         errorLine2="                                                          ~~~~~~">
         <location
-            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt"
-            line="181"
+            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt" line="186"
             column="59"/>
     </issue>
 
@@ -3293,8 +3252,7 @@
         errorLine1="        _columnsDataset.put(&quot;secondaryMuscles&quot;, TableInfo.Column(&quot;secondaryMuscles&quot;, &quot;TEXT&quot;, true, 0, null, TableInfo.CREATED_FROM_ENTITY))"
         errorLine2="                                                                 ~~~~~~~~~~~~~~~~~~">
         <location
-            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt"
-            line="181"
+            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt" line="186"
             column="66"/>
     </issue>
 
@@ -3304,8 +3262,7 @@
         errorLine1="        _columnsDataset.put(&quot;secondaryMuscles&quot;, TableInfo.Column(&quot;secondaryMuscles&quot;, &quot;TEXT&quot;, true, 0, null, TableInfo.CREATED_FROM_ENTITY))"
         errorLine2="                                                                                     ~~~~~~">
         <location
-            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt"
-            line="181"
+            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt" line="186"
             column="86"/>
     </issue>
 
@@ -3315,8 +3272,7 @@
         errorLine1="        _columnsDataset.put(&quot;secondaryMuscles&quot;, TableInfo.Column(&quot;secondaryMuscles&quot;, &quot;TEXT&quot;, true, 0, null, TableInfo.CREATED_FROM_ENTITY))"
         errorLine2="                                                                                                      ~~~~">
         <location
-            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt"
-            line="181"
+            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt" line="186"
             column="103"/>
     </issue>
 
@@ -3326,8 +3282,7 @@
         errorLine1="        _columnsDataset.put(&quot;secondaryMuscles&quot;, TableInfo.Column(&quot;secondaryMuscles&quot;, &quot;TEXT&quot;, true, 0, null, TableInfo.CREATED_FROM_ENTITY))"
         errorLine2="                                                                                                                      ~~~~~~~~~~~~~~~~~~~">
         <location
-            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt"
-            line="181"
+            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt" line="186"
             column="119"/>
     </issue>
 
@@ -3337,8 +3292,7 @@
         errorLine1="        _columnsDataset.put(&quot;instructions&quot;, TableInfo.Column(&quot;instructions&quot;, &quot;TEXT&quot;, true, 0, null, TableInfo.CREATED_FROM_ENTITY))"
         errorLine2="                                                      ~~~~~~">
         <location
-            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt"
-            line="182"
+            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt" line="187"
             column="55"/>
     </issue>
 
@@ -3348,8 +3302,7 @@
         errorLine1="        _columnsDataset.put(&quot;instructions&quot;, TableInfo.Column(&quot;instructions&quot;, &quot;TEXT&quot;, true, 0, null, TableInfo.CREATED_FROM_ENTITY))"
         errorLine2="                                                             ~~~~~~~~~~~~~~">
         <location
-            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt"
-            line="182"
+            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt" line="187"
             column="62"/>
     </issue>
 
@@ -3359,8 +3312,7 @@
         errorLine1="        _columnsDataset.put(&quot;instructions&quot;, TableInfo.Column(&quot;instructions&quot;, &quot;TEXT&quot;, true, 0, null, TableInfo.CREATED_FROM_ENTITY))"
         errorLine2="                                                                             ~~~~~~">
         <location
-            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt"
-            line="182"
+            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt" line="187"
             column="78"/>
     </issue>
 
@@ -3370,8 +3322,7 @@
         errorLine1="        _columnsDataset.put(&quot;instructions&quot;, TableInfo.Column(&quot;instructions&quot;, &quot;TEXT&quot;, true, 0, null, TableInfo.CREATED_FROM_ENTITY))"
         errorLine2="                                                                                              ~~~~">
         <location
-            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt"
-            line="182"
+            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt" line="187"
             column="95"/>
     </issue>
 
@@ -3381,8 +3332,7 @@
         errorLine1="        _columnsDataset.put(&quot;instructions&quot;, TableInfo.Column(&quot;instructions&quot;, &quot;TEXT&quot;, true, 0, null, TableInfo.CREATED_FROM_ENTITY))"
         errorLine2="                                                                                                              ~~~~~~~~~~~~~~~~~~~">
         <location
-            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt"
-            line="182"
+            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt" line="187"
             column="111"/>
     </issue>
 
@@ -3392,8 +3342,7 @@
         errorLine1="        _columnsDataset.put(&quot;category&quot;, TableInfo.Column(&quot;category&quot;, &quot;TEXT&quot;, true, 0, null, TableInfo.CREATED_FROM_ENTITY))"
         errorLine2="                                                  ~~~~~~">
         <location
-            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt"
-            line="183"
+            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt" line="188"
             column="51"/>
     </issue>
 
@@ -3403,8 +3352,7 @@
         errorLine1="        _columnsDataset.put(&quot;category&quot;, TableInfo.Column(&quot;category&quot;, &quot;TEXT&quot;, true, 0, null, TableInfo.CREATED_FROM_ENTITY))"
         errorLine2="                                                         ~~~~~~~~~~">
         <location
-            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt"
-            line="183"
+            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt" line="188"
             column="58"/>
     </issue>
 
@@ -3414,8 +3362,7 @@
         errorLine1="        _columnsDataset.put(&quot;category&quot;, TableInfo.Column(&quot;category&quot;, &quot;TEXT&quot;, true, 0, null, TableInfo.CREATED_FROM_ENTITY))"
         errorLine2="                                                                     ~~~~~~">
         <location
-            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt"
-            line="183"
+            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt" line="188"
             column="70"/>
     </issue>
 
@@ -3425,8 +3372,7 @@
         errorLine1="        _columnsDataset.put(&quot;category&quot;, TableInfo.Column(&quot;category&quot;, &quot;TEXT&quot;, true, 0, null, TableInfo.CREATED_FROM_ENTITY))"
         errorLine2="                                                                                      ~~~~">
         <location
-            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt"
-            line="183"
+            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt" line="188"
             column="87"/>
     </issue>
 
@@ -3436,8 +3382,7 @@
         errorLine1="        _columnsDataset.put(&quot;category&quot;, TableInfo.Column(&quot;category&quot;, &quot;TEXT&quot;, true, 0, null, TableInfo.CREATED_FROM_ENTITY))"
         errorLine2="                                                                                                      ~~~~~~~~~~~~~~~~~~~">
         <location
-            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt"
-            line="183"
+            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt" line="188"
             column="103"/>
     </issue>
 
@@ -3447,8 +3392,7 @@
         errorLine1="        _columnsDataset.put(&quot;images&quot;, TableInfo.Column(&quot;images&quot;, &quot;TEXT&quot;, true, 0, null, TableInfo.CREATED_FROM_ENTITY))"
         errorLine2="                                                ~~~~~~">
         <location
-            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt"
-            line="184"
+            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt" line="189"
             column="49"/>
     </issue>
 
@@ -3458,8 +3402,7 @@
         errorLine1="        _columnsDataset.put(&quot;images&quot;, TableInfo.Column(&quot;images&quot;, &quot;TEXT&quot;, true, 0, null, TableInfo.CREATED_FROM_ENTITY))"
         errorLine2="                                                       ~~~~~~~~">
         <location
-            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt"
-            line="184"
+            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt" line="189"
             column="56"/>
     </issue>
 
@@ -3469,8 +3412,7 @@
         errorLine1="        _columnsDataset.put(&quot;images&quot;, TableInfo.Column(&quot;images&quot;, &quot;TEXT&quot;, true, 0, null, TableInfo.CREATED_FROM_ENTITY))"
         errorLine2="                                                                 ~~~~~~">
         <location
-            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt"
-            line="184"
+            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt" line="189"
             column="66"/>
     </issue>
 
@@ -3480,8 +3422,7 @@
         errorLine1="        _columnsDataset.put(&quot;images&quot;, TableInfo.Column(&quot;images&quot;, &quot;TEXT&quot;, true, 0, null, TableInfo.CREATED_FROM_ENTITY))"
         errorLine2="                                                                                  ~~~~">
         <location
-            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt"
-            line="184"
+            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt" line="189"
             column="83"/>
     </issue>
 
@@ -3491,8 +3432,7 @@
         errorLine1="        _columnsDataset.put(&quot;images&quot;, TableInfo.Column(&quot;images&quot;, &quot;TEXT&quot;, true, 0, null, TableInfo.CREATED_FROM_ENTITY))"
         errorLine2="                                                                                                  ~~~~~~~~~~~~~~~~~~~">
         <location
-            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt"
-            line="184"
+            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt" line="189"
             column="99"/>
     </issue>
 
@@ -3502,8 +3442,7 @@
         errorLine1="        _columnsDataset.put(&quot;isCustomExercise&quot;, TableInfo.Column(&quot;isCustomExercise&quot;, &quot;INTEGER&quot;, true, 0, null, TableInfo.CREATED_FROM_ENTITY))"
         errorLine2="                                                          ~~~~~~">
         <location
-            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt"
-            line="185"
+            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt" line="190"
             column="59"/>
     </issue>
 
@@ -3513,8 +3452,7 @@
         errorLine1="        _columnsDataset.put(&quot;isCustomExercise&quot;, TableInfo.Column(&quot;isCustomExercise&quot;, &quot;INTEGER&quot;, true, 0, null, TableInfo.CREATED_FROM_ENTITY))"
         errorLine2="                                                                 ~~~~~~~~~~~~~~~~~~">
         <location
-            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt"
-            line="185"
+            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt" line="190"
             column="66"/>
     </issue>
 
@@ -3524,8 +3462,7 @@
         errorLine1="        _columnsDataset.put(&quot;isCustomExercise&quot;, TableInfo.Column(&quot;isCustomExercise&quot;, &quot;INTEGER&quot;, true, 0, null, TableInfo.CREATED_FROM_ENTITY))"
         errorLine2="                                                                                     ~~~~~~~~~">
         <location
-            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt"
-            line="185"
+            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt" line="190"
             column="86"/>
     </issue>
 
@@ -3535,8 +3472,7 @@
         errorLine1="        _columnsDataset.put(&quot;isCustomExercise&quot;, TableInfo.Column(&quot;isCustomExercise&quot;, &quot;INTEGER&quot;, true, 0, null, TableInfo.CREATED_FROM_ENTITY))"
         errorLine2="                                                                                                         ~~~~">
         <location
-            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt"
-            line="185"
+            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt" line="190"
             column="106"/>
     </issue>
 
@@ -3546,8 +3482,7 @@
         errorLine1="        _columnsDataset.put(&quot;isCustomExercise&quot;, TableInfo.Column(&quot;isCustomExercise&quot;, &quot;INTEGER&quot;, true, 0, null, TableInfo.CREATED_FROM_ENTITY))"
         errorLine2="                                                                                                                         ~~~~~~~~~~~~~~~~~~~">
         <location
-            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt"
-            line="185"
+            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt" line="190"
             column="122"/>
     </issue>
 
@@ -3557,8 +3492,7 @@
         errorLine1="        val _foreignKeysDataset: MutableSet&lt;TableInfo.ForeignKey> = mutableSetOf()"
         errorLine2="                                            ~~~~~~~~~~~~~~~~~~~~">
         <location
-            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt"
-            line="186"
+            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt" line="191"
             column="45"/>
     </issue>
 
@@ -3568,8 +3502,7 @@
         errorLine1="        val _indicesDataset: MutableSet&lt;TableInfo.Index> = mutableSetOf()"
         errorLine2="                                        ~~~~~~~~~~~~~~~">
         <location
-            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt"
-            line="187"
+            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt" line="192"
             column="41"/>
     </issue>
 
@@ -3579,8 +3512,7 @@
         errorLine1="        val _infoDataset: TableInfo = TableInfo(&quot;dataset&quot;, _columnsDataset, _foreignKeysDataset, _indicesDataset)"
         errorLine2="                          ~~~~~~~~~">
         <location
-            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt"
-            line="188"
+            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt" line="193"
             column="27"/>
     </issue>
 
@@ -3590,8 +3522,7 @@
         errorLine1="        val _infoDataset: TableInfo = TableInfo(&quot;dataset&quot;, _columnsDataset, _foreignKeysDataset, _indicesDataset)"
         errorLine2="                                      ~~~~~~~~~">
         <location
-            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt"
-            line="188"
+            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt" line="193"
             column="39"/>
     </issue>
 
@@ -3601,8 +3532,7 @@
         errorLine1="        val _infoDataset: TableInfo = TableInfo(&quot;dataset&quot;, _columnsDataset, _foreignKeysDataset, _indicesDataset)"
         errorLine2="                                                ~~~~~~~~~">
         <location
-            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt"
-            line="188"
+            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt" line="193"
             column="49"/>
     </issue>
 
@@ -3612,8 +3542,7 @@
         errorLine1="        val _infoDataset: TableInfo = TableInfo(&quot;dataset&quot;, _columnsDataset, _foreignKeysDataset, _indicesDataset)"
         errorLine2="                                                           ~~~~~~~~~~~~~~~">
         <location
-            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt"
-            line="188"
+            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt" line="193"
             column="60"/>
     </issue>
 
@@ -3623,8 +3552,7 @@
         errorLine1="        val _infoDataset: TableInfo = TableInfo(&quot;dataset&quot;, _columnsDataset, _foreignKeysDataset, _indicesDataset)"
         errorLine2="                                                                            ~~~~~~~~~~~~~~~~~~~">
         <location
-            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt"
-            line="188"
+            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt" line="193"
             column="77"/>
     </issue>
 
@@ -3634,8 +3562,7 @@
         errorLine1="        val _infoDataset: TableInfo = TableInfo(&quot;dataset&quot;, _columnsDataset, _foreignKeysDataset, _indicesDataset)"
         errorLine2="                                                                                                 ~~~~~~~~~~~~~~~">
         <location
-            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt"
-            line="188"
+            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt" line="193"
             column="98"/>
     </issue>
 
@@ -3645,8 +3572,7 @@
         errorLine1="        val _existingDataset: TableInfo = read(connection, &quot;dataset&quot;)"
         errorLine2="                                          ~~~~">
         <location
-            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt"
-            line="189"
+            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt" line="194"
             column="43"/>
     </issue>
 
@@ -3656,8 +3582,7 @@
         errorLine1="        val _existingDataset: TableInfo = read(connection, &quot;dataset&quot;)"
         errorLine2="                                               ~~~~~~~~~~">
         <location
-            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt"
-            line="189"
+            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt" line="194"
             column="48"/>
     </issue>
 
@@ -3667,8 +3592,7 @@
         errorLine1="        val _existingDataset: TableInfo = read(connection, &quot;dataset&quot;)"
         errorLine2="                                                           ~~~~~~~~~">
         <location
-            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt"
-            line="189"
+            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt" line="194"
             column="60"/>
     </issue>
 
@@ -3678,8 +3602,7 @@
         errorLine1="        val _existingDataset: TableInfo = read(connection, &quot;dataset&quot;)"
         errorLine2="                              ~~~~~~~~~">
         <location
-            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt"
-            line="189"
+            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt" line="194"
             column="31"/>
     </issue>
 
@@ -3689,8 +3612,7 @@
         errorLine1="        if (!_infoDataset.equals(_existingDataset)) {"
         errorLine2="                          ~~~~~~">
         <location
-            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt"
-            line="190"
+            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt" line="195"
             column="27"/>
     </issue>
 
@@ -3700,8 +3622,7 @@
         errorLine1="        if (!_infoDataset.equals(_existingDataset)) {"
         errorLine2="                                 ~~~~~~~~~~~~~~~~">
         <location
-            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt"
-            line="190"
+            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt" line="195"
             column="34"/>
     </issue>
 
@@ -3711,8 +3632,7 @@
         errorLine1="          return RoomOpenDelegate.ValidationResult(false, &quot;&quot;&quot;"
         errorLine2="                                  ~~~~~~~~~~~~~~~~">
         <location
-            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt"
-            line="191"
+            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt" line="196"
             column="35"/>
     </issue>
 
@@ -3722,8 +3642,7 @@
         errorLine1="          return RoomOpenDelegate.ValidationResult(false, &quot;&quot;&quot;"
         errorLine2="                                                          ^">
         <location
-            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt"
-            line="191"
+            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt" line="196"
             column="59"/>
     </issue>
 
@@ -3733,8 +3652,7 @@
         errorLine1="        return RoomOpenDelegate.ValidationResult(true, null)"
         errorLine2="                                ~~~~~~~~~~~~~~~~">
         <location
-            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt"
-            line="199"
+            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt" line="204"
             column="33"/>
     </issue>
 
@@ -3744,8 +3662,7 @@
         errorLine1="        return RoomOpenDelegate.ValidationResult(true, null)"
         errorLine2="                                                       ~~~~">
         <location
-            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt"
-            line="199"
+            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt" line="204"
             column="56"/>
     </issue>
 
@@ -3755,8 +3672,7 @@
         errorLine1="    return InvalidationTracker(this, _shadowTablesMap, _viewTables, &quot;workouts&quot;, &quot;exercises&quot;, &quot;sets&quot;, &quot;measurements&quot;, &quot;dataset&quot;)"
         errorLine2="           ~~~~~~~~~~~~~~~~~~~">
         <location
-            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt"
-            line="208"
+            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt" line="213"
             column="12"/>
     </issue>
 
@@ -3766,8 +3682,7 @@
         errorLine1="    super.performClear(true, &quot;workouts&quot;, &quot;exercises&quot;, &quot;sets&quot;, &quot;measurements&quot;, &quot;dataset&quot;)"
         errorLine2="          ~~~~~~~~~~~~">
         <location
-            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt"
-            line="212"
+            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt" line="217"
             column="11"/>
     </issue>
 
@@ -3777,8 +3692,7 @@
         errorLine1="  protected override fun getRequiredTypeConverterClasses(): Map&lt;KClass&lt;*>, List&lt;KClass&lt;*>>> {"
         errorLine2="                         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
-            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt"
-            line="215"
+            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt" line="220"
             column="26"/>
     </issue>
 
@@ -3788,8 +3702,7 @@
         errorLine1="  public override fun getRequiredAutoMigrationSpecClasses(): Set&lt;KClass&lt;out AutoMigrationSpec>> {"
         errorLine2="                      ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
-            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt"
-            line="223"
+            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt" line="228"
             column="23"/>
     </issue>
 
@@ -3799,8 +3712,7 @@
         errorLine1="  public override fun createAutoMigrations(autoMigrationSpecs: Map&lt;KClass&lt;out AutoMigrationSpec>, AutoMigrationSpec>): List&lt;Migration> {"
         errorLine2="                      ~~~~~~~~~~~~~~~~~~~~">
         <location
-            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt"
-            line="228"
+            file="build/generated/ksp/debug/kotlin/org/librefit/db/AppDatabase_Impl.kt" line="233"
             column="23"/>
     </issue>
 
@@ -4697,17 +4609,6 @@
 
     <issue
         id="RestrictedApi"
-        message="Companion.getDefault can only be called from within the same library group (referenced groupId=`com.patrykandpatrick.vico` from groupId=`LibreFit`)"
-        errorLine1="                                            else CartesianValueFormatter.Default"
-        errorLine2="                                                                         ~~~~~~~">
-        <location
-            file="src/main/java/org/librefit/ui/components/charts/LibreFitCartesianChart.kt"
-            line="411"
-            column="74"/>
-    </issue>
-
-    <issue
-        id="RestrictedApi"
         message="EntityDeleteOrUpdateAdapter can only be accessed from within the same library group prefix (referenced groupId=`androidx.room` with prefix androidx from groupId=`LibreFit`)"
         errorLine1="  private val __deleteAdapterOfMeasurement: EntityDeleteOrUpdateAdapter&lt;Measurement>"
         errorLine2="                                            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
@@ -5314,7 +5215,7 @@
     <issue
         id="RestrictedApi"
         message="EntityInsertAdapter.createQuery can only be called from within the same library group prefix (referenced groupId=`androidx.room` with prefix androidx from groupId=`LibreFit`)"
-        errorLine1="      protected override fun createQuery(): String = &quot;INSERT OR ABORT INTO `exercises` (`id`,`idExerciseDC`,`notes`,`setMode`,`restTime`,`workoutId`) VALUES (nullif(?, 0),?,?,?,?,?)&quot;"
+        errorLine1="      protected override fun createQuery(): String = &quot;INSERT OR ABORT INTO `exercises` (`id`,`idExerciseDC`,`notes`,`setMode`,`restTime`,`position`,`workoutId`) VALUES (nullif(?, 0),?,?,?,?,?,?)&quot;"
         errorLine2="                             ~~~~~~~~~~~">
         <location
             file="build/generated/ksp/debug/kotlin/org/librefit/db/dao/WorkoutDao_Impl.kt"
@@ -5340,7 +5241,7 @@
         errorLine2="                                ^">
         <location
             file="build/generated/ksp/debug/kotlin/org/librefit/db/dao/WorkoutDao_Impl.kt"
-            line="118"
+            line="119"
             column="33"/>
     </issue>
 
@@ -5351,7 +5252,7 @@
         errorLine2="                                         ~~~~~~~~~~~~~~~~~~~">
         <location
             file="build/generated/ksp/debug/kotlin/org/librefit/db/dao/WorkoutDao_Impl.kt"
-            line="118"
+            line="119"
             column="42"/>
     </issue>
 
@@ -5362,7 +5263,7 @@
         errorLine2="                             ~~~~~~~~~~~">
         <location
             file="build/generated/ksp/debug/kotlin/org/librefit/db/dao/WorkoutDao_Impl.kt"
-            line="119"
+            line="120"
             column="30"/>
     </issue>
 
@@ -5373,7 +5274,7 @@
         errorLine2="                             ~~~~">
         <location
             file="build/generated/ksp/debug/kotlin/org/librefit/db/dao/WorkoutDao_Impl.kt"
-            line="121"
+            line="122"
             column="30"/>
     </issue>
 
@@ -5384,7 +5285,7 @@
         errorLine2="                                    ^">
         <location
             file="build/generated/ksp/debug/kotlin/org/librefit/db/dao/WorkoutDao_Impl.kt"
-            line="131"
+            line="132"
             column="37"/>
     </issue>
 
@@ -5395,7 +5296,7 @@
         errorLine2="                                             ~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="build/generated/ksp/debug/kotlin/org/librefit/db/dao/WorkoutDao_Impl.kt"
-            line="131"
+            line="132"
             column="46"/>
     </issue>
 
@@ -5406,7 +5307,7 @@
         errorLine2="                             ~~~~~~~~~~~">
         <location
             file="build/generated/ksp/debug/kotlin/org/librefit/db/dao/WorkoutDao_Impl.kt"
-            line="132"
+            line="133"
             column="30"/>
     </issue>
 
@@ -5417,7 +5318,7 @@
         errorLine2="                             ~~~~">
         <location
             file="build/generated/ksp/debug/kotlin/org/librefit/db/dao/WorkoutDao_Impl.kt"
-            line="134"
+            line="135"
             column="30"/>
     </issue>
 
@@ -5428,7 +5329,7 @@
         errorLine2="                                     ^">
         <location
             file="build/generated/ksp/debug/kotlin/org/librefit/db/dao/WorkoutDao_Impl.kt"
-            line="138"
+            line="139"
             column="38"/>
     </issue>
 
@@ -5439,7 +5340,7 @@
         errorLine2="                                              ~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="build/generated/ksp/debug/kotlin/org/librefit/db/dao/WorkoutDao_Impl.kt"
-            line="138"
+            line="139"
             column="47"/>
     </issue>
 
@@ -5450,7 +5351,7 @@
         errorLine2="                             ~~~~~~~~~~~">
         <location
             file="build/generated/ksp/debug/kotlin/org/librefit/db/dao/WorkoutDao_Impl.kt"
-            line="139"
+            line="140"
             column="30"/>
     </issue>
 
@@ -5461,7 +5362,7 @@
         errorLine2="                             ~~~~">
         <location
             file="build/generated/ksp/debug/kotlin/org/librefit/db/dao/WorkoutDao_Impl.kt"
-            line="141"
+            line="142"
             column="30"/>
     </issue>
 
@@ -5472,7 +5373,7 @@
         errorLine2="                                ^">
         <location
             file="build/generated/ksp/debug/kotlin/org/librefit/db/dao/WorkoutDao_Impl.kt"
-            line="145"
+            line="146"
             column="33"/>
     </issue>
 
@@ -5483,7 +5384,7 @@
         errorLine2="                                         ~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="build/generated/ksp/debug/kotlin/org/librefit/db/dao/WorkoutDao_Impl.kt"
-            line="145"
+            line="146"
             column="42"/>
     </issue>
 
@@ -5494,7 +5395,7 @@
         errorLine2="                             ~~~~~~~~~~~">
         <location
             file="build/generated/ksp/debug/kotlin/org/librefit/db/dao/WorkoutDao_Impl.kt"
-            line="146"
+            line="147"
             column="30"/>
     </issue>
 
@@ -5505,7 +5406,7 @@
         errorLine2="                             ~~~~">
         <location
             file="build/generated/ksp/debug/kotlin/org/librefit/db/dao/WorkoutDao_Impl.kt"
-            line="148"
+            line="149"
             column="30"/>
     </issue>
 
@@ -5516,7 +5417,7 @@
         errorLine2="                                    ^">
         <location
             file="build/generated/ksp/debug/kotlin/org/librefit/db/dao/WorkoutDao_Impl.kt"
-            line="152"
+            line="153"
             column="37"/>
     </issue>
 
@@ -5527,7 +5428,7 @@
         errorLine2="                                             ~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="build/generated/ksp/debug/kotlin/org/librefit/db/dao/WorkoutDao_Impl.kt"
-            line="152"
+            line="153"
             column="46"/>
     </issue>
 
@@ -5538,7 +5439,7 @@
         errorLine2="                             ~~~~~~~~~~~">
         <location
             file="build/generated/ksp/debug/kotlin/org/librefit/db/dao/WorkoutDao_Impl.kt"
-            line="153"
+            line="154"
             column="30"/>
     </issue>
 
@@ -5549,7 +5450,7 @@
         errorLine2="                             ~~~~">
         <location
             file="build/generated/ksp/debug/kotlin/org/librefit/db/dao/WorkoutDao_Impl.kt"
-            line="155"
+            line="156"
             column="30"/>
     </issue>
 
@@ -5560,7 +5461,7 @@
         errorLine2="                                     ^">
         <location
             file="build/generated/ksp/debug/kotlin/org/librefit/db/dao/WorkoutDao_Impl.kt"
-            line="177"
+            line="178"
             column="38"/>
     </issue>
 
@@ -5571,18 +5472,18 @@
         errorLine2="                                              ~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="build/generated/ksp/debug/kotlin/org/librefit/db/dao/WorkoutDao_Impl.kt"
-            line="177"
+            line="178"
             column="47"/>
     </issue>
 
     <issue
         id="RestrictedApi"
         message="EntityDeleteOrUpdateAdapter.createQuery can only be called from within the same library group prefix (referenced groupId=`androidx.room` with prefix androidx from groupId=`LibreFit`)"
-        errorLine1="      protected override fun createQuery(): String = &quot;UPDATE OR ABORT `exercises` SET `id` = ?,`idExerciseDC` = ?,`notes` = ?,`setMode` = ?,`restTime` = ?,`workoutId` = ? WHERE `id` = ?&quot;"
+        errorLine1="      protected override fun createQuery(): String = &quot;UPDATE OR ABORT `exercises` SET `id` = ?,`idExerciseDC` = ?,`notes` = ?,`setMode` = ?,`restTime` = ?,`position` = ?,`workoutId` = ? WHERE `id` = ?&quot;"
         errorLine2="                             ~~~~~~~~~~~">
         <location
             file="build/generated/ksp/debug/kotlin/org/librefit/db/dao/WorkoutDao_Impl.kt"
-            line="178"
+            line="179"
             column="30"/>
     </issue>
 
@@ -5593,7 +5494,7 @@
         errorLine2="                             ~~~~">
         <location
             file="build/generated/ksp/debug/kotlin/org/librefit/db/dao/WorkoutDao_Impl.kt"
-            line="180"
+            line="181"
             column="30"/>
     </issue>
 
@@ -5604,7 +5505,7 @@
         errorLine2="                                ^">
         <location
             file="build/generated/ksp/debug/kotlin/org/librefit/db/dao/WorkoutDao_Impl.kt"
-            line="190"
+            line="192"
             column="33"/>
     </issue>
 
@@ -5615,7 +5516,7 @@
         errorLine2="                                         ~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="build/generated/ksp/debug/kotlin/org/librefit/db/dao/WorkoutDao_Impl.kt"
-            line="190"
+            line="192"
             column="42"/>
     </issue>
 
@@ -5626,7 +5527,7 @@
         errorLine2="                             ~~~~~~~~~~~">
         <location
             file="build/generated/ksp/debug/kotlin/org/librefit/db/dao/WorkoutDao_Impl.kt"
-            line="191"
+            line="193"
             column="30"/>
     </issue>
 
@@ -5637,7 +5538,7 @@
         errorLine2="                             ~~~~">
         <location
             file="build/generated/ksp/debug/kotlin/org/librefit/db/dao/WorkoutDao_Impl.kt"
-            line="193"
+            line="195"
             column="30"/>
     </issue>
 
@@ -5648,7 +5549,7 @@
         errorLine2="                                                                   ~~~~~~~~~~~~~~~~~">
         <location
             file="build/generated/ksp/debug/kotlin/org/librefit/db/dao/WorkoutDao_Impl.kt"
-            line="206"
+            line="208"
             column="68"/>
     </issue>
 
@@ -5659,7 +5560,7 @@
         errorLine2="                                                 ~~~~~~~~~~~~~~~~~">
         <location
             file="build/generated/ksp/debug/kotlin/org/librefit/db/dao/WorkoutDao_Impl.kt"
-            line="207"
+            line="209"
             column="50"/>
     </issue>
 
@@ -5670,7 +5571,7 @@
         errorLine2="                                                                   ~~~~~~~~~~~">
         <location
             file="build/generated/ksp/debug/kotlin/org/librefit/db/dao/WorkoutDao_Impl.kt"
-            line="207"
+            line="209"
             column="68"/>
     </issue>
 
@@ -5681,7 +5582,7 @@
         errorLine2="                                                                                ~~~~~~~">
         <location
             file="build/generated/ksp/debug/kotlin/org/librefit/db/dao/WorkoutDao_Impl.kt"
-            line="207"
+            line="209"
             column="81"/>
     </issue>
 
@@ -5692,7 +5593,7 @@
         errorLine2="                                                                      ~~~~~~~~~~~~~~~~~">
         <location
             file="build/generated/ksp/debug/kotlin/org/librefit/db/dao/WorkoutDao_Impl.kt"
-            line="211"
+            line="213"
             column="71"/>
     </issue>
 
@@ -5703,7 +5604,7 @@
         errorLine2="                                                  ~~~~~~~~~~~~~~~~~">
         <location
             file="build/generated/ksp/debug/kotlin/org/librefit/db/dao/WorkoutDao_Impl.kt"
-            line="212"
+            line="214"
             column="51"/>
     </issue>
 
@@ -5714,7 +5615,7 @@
         errorLine2="                                                                    ~~~~~~~~~~~">
         <location
             file="build/generated/ksp/debug/kotlin/org/librefit/db/dao/WorkoutDao_Impl.kt"
-            line="212"
+            line="214"
             column="69"/>
     </issue>
 
@@ -5725,7 +5626,7 @@
         errorLine2="                                                                                 ~~~~~~~~">
         <location
             file="build/generated/ksp/debug/kotlin/org/librefit/db/dao/WorkoutDao_Impl.kt"
-            line="212"
+            line="214"
             column="82"/>
     </issue>
 
@@ -5736,7 +5637,7 @@
         errorLine2="                                                               ~~~~~~~~~~~~~~~~~">
         <location
             file="build/generated/ksp/debug/kotlin/org/librefit/db/dao/WorkoutDao_Impl.kt"
-            line="216"
+            line="218"
             column="64"/>
     </issue>
 
@@ -5747,7 +5648,7 @@
         errorLine2="                         ~~~~~~">
         <location
             file="build/generated/ksp/debug/kotlin/org/librefit/db/dao/WorkoutDao_Impl.kt"
-            line="217"
+            line="219"
             column="26"/>
     </issue>
 
@@ -5758,7 +5659,7 @@
         errorLine2="                                ~~~~~~~~~~~">
         <location
             file="build/generated/ksp/debug/kotlin/org/librefit/db/dao/WorkoutDao_Impl.kt"
-            line="217"
+            line="219"
             column="33"/>
     </issue>
 
@@ -5769,7 +5670,7 @@
         errorLine2="                                             ~~~">
         <location
             file="build/generated/ksp/debug/kotlin/org/librefit/db/dao/WorkoutDao_Impl.kt"
-            line="217"
+            line="219"
             column="46"/>
     </issue>
 
@@ -5780,7 +5681,7 @@
         errorLine2="                                                                      ~~~~~~~~~~~~~~~~~">
         <location
             file="build/generated/ksp/debug/kotlin/org/librefit/db/dao/WorkoutDao_Impl.kt"
-            line="220"
+            line="222"
             column="71"/>
     </issue>
 
@@ -5791,7 +5692,7 @@
         errorLine2="                             ~~~~~~">
         <location
             file="build/generated/ksp/debug/kotlin/org/librefit/db/dao/WorkoutDao_Impl.kt"
-            line="221"
+            line="223"
             column="30"/>
     </issue>
 
@@ -5802,7 +5703,7 @@
         errorLine2="                                    ~~~~~~~~~~~">
         <location
             file="build/generated/ksp/debug/kotlin/org/librefit/db/dao/WorkoutDao_Impl.kt"
-            line="221"
+            line="223"
             column="37"/>
     </issue>
 
@@ -5813,7 +5714,7 @@
         errorLine2="                                                 ~~~~~~~">
         <location
             file="build/generated/ksp/debug/kotlin/org/librefit/db/dao/WorkoutDao_Impl.kt"
-            line="221"
+            line="223"
             column="50"/>
     </issue>
 
@@ -5824,7 +5725,7 @@
         errorLine2="                                                                         ~~~~~~~~~~~~~~~~~">
         <location
             file="build/generated/ksp/debug/kotlin/org/librefit/db/dao/WorkoutDao_Impl.kt"
-            line="224"
+            line="226"
             column="74"/>
     </issue>
 
@@ -5835,7 +5736,7 @@
         errorLine2="                              ~~~~~~">
         <location
             file="build/generated/ksp/debug/kotlin/org/librefit/db/dao/WorkoutDao_Impl.kt"
-            line="225"
+            line="227"
             column="31"/>
     </issue>
 
@@ -5846,7 +5747,7 @@
         errorLine2="                                     ~~~~~~~~~~~">
         <location
             file="build/generated/ksp/debug/kotlin/org/librefit/db/dao/WorkoutDao_Impl.kt"
-            line="225"
+            line="227"
             column="38"/>
     </issue>
 
@@ -5857,7 +5758,7 @@
         errorLine2="                                                  ~~~~~~~~">
         <location
             file="build/generated/ksp/debug/kotlin/org/librefit/db/dao/WorkoutDao_Impl.kt"
-            line="225"
+            line="227"
             column="51"/>
     </issue>
 
@@ -5868,7 +5769,7 @@
         errorLine2="                                                                  ~~~~~~~~~~~~~~~~~">
         <location
             file="build/generated/ksp/debug/kotlin/org/librefit/db/dao/WorkoutDao_Impl.kt"
-            line="228"
+            line="230"
             column="67"/>
     </issue>
 
@@ -5879,7 +5780,7 @@
         errorLine2="                         ~~~~~~">
         <location
             file="build/generated/ksp/debug/kotlin/org/librefit/db/dao/WorkoutDao_Impl.kt"
-            line="229"
+            line="231"
             column="26"/>
     </issue>
 
@@ -5890,7 +5791,7 @@
         errorLine2="                                ~~~~~~~~~~~">
         <location
             file="build/generated/ksp/debug/kotlin/org/librefit/db/dao/WorkoutDao_Impl.kt"
-            line="229"
+            line="231"
             column="33"/>
     </issue>
 
@@ -5901,7 +5802,7 @@
         errorLine2="                                             ~~~">
         <location
             file="build/generated/ksp/debug/kotlin/org/librefit/db/dao/WorkoutDao_Impl.kt"
-            line="229"
+            line="231"
             column="46"/>
     </issue>
 
@@ -5912,7 +5813,7 @@
         errorLine2="                                                                      ~~~~~~~~~~~~~~~~~">
         <location
             file="build/generated/ksp/debug/kotlin/org/librefit/db/dao/WorkoutDao_Impl.kt"
-            line="232"
+            line="234"
             column="71"/>
     </issue>
 
@@ -5923,7 +5824,7 @@
         errorLine2="                             ~~~~~~">
         <location
             file="build/generated/ksp/debug/kotlin/org/librefit/db/dao/WorkoutDao_Impl.kt"
-            line="233"
+            line="235"
             column="30"/>
     </issue>
 
@@ -5934,7 +5835,7 @@
         errorLine2="                                    ~~~~~~~~~~~">
         <location
             file="build/generated/ksp/debug/kotlin/org/librefit/db/dao/WorkoutDao_Impl.kt"
-            line="233"
+            line="235"
             column="37"/>
     </issue>
 
@@ -5945,7 +5846,7 @@
         errorLine2="                                                 ~~~~~~~">
         <location
             file="build/generated/ksp/debug/kotlin/org/librefit/db/dao/WorkoutDao_Impl.kt"
-            line="233"
+            line="235"
             column="50"/>
     </issue>
 
@@ -5956,7 +5857,7 @@
         errorLine2="                                                                         ~~~~~~~~~~~~~~~~~">
         <location
             file="build/generated/ksp/debug/kotlin/org/librefit/db/dao/WorkoutDao_Impl.kt"
-            line="236"
+            line="238"
             column="74"/>
     </issue>
 
@@ -5967,7 +5868,7 @@
         errorLine2="                              ~~~~~~">
         <location
             file="build/generated/ksp/debug/kotlin/org/librefit/db/dao/WorkoutDao_Impl.kt"
-            line="237"
+            line="239"
             column="31"/>
     </issue>
 
@@ -5978,7 +5879,7 @@
         errorLine2="                                     ~~~~~~~~~~~">
         <location
             file="build/generated/ksp/debug/kotlin/org/librefit/db/dao/WorkoutDao_Impl.kt"
-            line="237"
+            line="239"
             column="38"/>
     </issue>
 
@@ -5989,7 +5890,7 @@
         errorLine2="                                                  ~~~~~~~~">
         <location
             file="build/generated/ksp/debug/kotlin/org/librefit/db/dao/WorkoutDao_Impl.kt"
-            line="237"
+            line="239"
             column="51"/>
     </issue>
 
@@ -6000,7 +5901,7 @@
         errorLine2="                                                                  ~~~~~~~~~~~~~~~~~">
         <location
             file="build/generated/ksp/debug/kotlin/org/librefit/db/dao/WorkoutDao_Impl.kt"
-            line="240"
+            line="242"
             column="67"/>
     </issue>
 
@@ -6011,7 +5912,7 @@
         errorLine2="                         ~~~~~~">
         <location
             file="build/generated/ksp/debug/kotlin/org/librefit/db/dao/WorkoutDao_Impl.kt"
-            line="241"
+            line="243"
             column="26"/>
     </issue>
 
@@ -6022,7 +5923,7 @@
         errorLine2="                                ~~~~~~~~~~~">
         <location
             file="build/generated/ksp/debug/kotlin/org/librefit/db/dao/WorkoutDao_Impl.kt"
-            line="241"
+            line="243"
             column="33"/>
     </issue>
 
@@ -6033,7 +5934,7 @@
         errorLine2="                                             ~~~">
         <location
             file="build/generated/ksp/debug/kotlin/org/librefit/db/dao/WorkoutDao_Impl.kt"
-            line="241"
+            line="243"
             column="46"/>
     </issue>
 
@@ -6044,7 +5945,7 @@
         errorLine2="                                                                                                                               ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="build/generated/ksp/debug/kotlin/org/librefit/db/dao/WorkoutDao_Impl.kt"
-            line="244"
+            line="246"
             column="128"/>
     </issue>
 
@@ -6055,7 +5956,7 @@
         errorLine2="           ~~~~~~~~~~">
         <location
             file="build/generated/ksp/debug/kotlin/org/librefit/db/dao/WorkoutDao_Impl.kt"
-            line="250"
+            line="252"
             column="12"/>
     </issue>
 
@@ -6066,7 +5967,7 @@
         errorLine2="                                    ~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="build/generated/ksp/debug/kotlin/org/librefit/db/dao/WorkoutDao_Impl.kt"
-            line="255"
+            line="257"
             column="37"/>
     </issue>
 
@@ -6077,7 +5978,7 @@
         errorLine2="                                           ~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="build/generated/ksp/debug/kotlin/org/librefit/db/dao/WorkoutDao_Impl.kt"
-            line="256"
+            line="258"
             column="44"/>
     </issue>
 
@@ -6085,28 +5986,6 @@
         id="RestrictedApi"
         message="SQLiteStatementUtil__StatementUtilKt.getColumnIndexOrThrow can only be called from within the same library group prefix (referenced groupId=`androidx.room` with prefix androidx from groupId=`LibreFit`)"
         errorLine1="        val _columnIndexOfNotes: Int = getColumnIndexOrThrow(_stmt, &quot;notes&quot;)"
-        errorLine2="                                       ~~~~~~~~~~~~~~~~~~~~~">
-        <location
-            file="build/generated/ksp/debug/kotlin/org/librefit/db/dao/WorkoutDao_Impl.kt"
-            line="257"
-            column="40"/>
-    </issue>
-
-    <issue
-        id="RestrictedApi"
-        message="SQLiteStatementUtil__StatementUtilKt.getColumnIndexOrThrow can only be called from within the same library group prefix (referenced groupId=`androidx.room` with prefix androidx from groupId=`LibreFit`)"
-        errorLine1="        val _columnIndexOfTitle: Int = getColumnIndexOrThrow(_stmt, &quot;title&quot;)"
-        errorLine2="                                       ~~~~~~~~~~~~~~~~~~~~~">
-        <location
-            file="build/generated/ksp/debug/kotlin/org/librefit/db/dao/WorkoutDao_Impl.kt"
-            line="258"
-            column="40"/>
-    </issue>
-
-    <issue
-        id="RestrictedApi"
-        message="SQLiteStatementUtil__StatementUtilKt.getColumnIndexOrThrow can only be called from within the same library group prefix (referenced groupId=`androidx.room` with prefix androidx from groupId=`LibreFit`)"
-        errorLine1="        val _columnIndexOfState: Int = getColumnIndexOrThrow(_stmt, &quot;state&quot;)"
         errorLine2="                                       ~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="build/generated/ksp/debug/kotlin/org/librefit/db/dao/WorkoutDao_Impl.kt"
@@ -6117,11 +5996,33 @@
     <issue
         id="RestrictedApi"
         message="SQLiteStatementUtil__StatementUtilKt.getColumnIndexOrThrow can only be called from within the same library group prefix (referenced groupId=`androidx.room` with prefix androidx from groupId=`LibreFit`)"
+        errorLine1="        val _columnIndexOfTitle: Int = getColumnIndexOrThrow(_stmt, &quot;title&quot;)"
+        errorLine2="                                       ~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="build/generated/ksp/debug/kotlin/org/librefit/db/dao/WorkoutDao_Impl.kt"
+            line="260"
+            column="40"/>
+    </issue>
+
+    <issue
+        id="RestrictedApi"
+        message="SQLiteStatementUtil__StatementUtilKt.getColumnIndexOrThrow can only be called from within the same library group prefix (referenced groupId=`androidx.room` with prefix androidx from groupId=`LibreFit`)"
+        errorLine1="        val _columnIndexOfState: Int = getColumnIndexOrThrow(_stmt, &quot;state&quot;)"
+        errorLine2="                                       ~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="build/generated/ksp/debug/kotlin/org/librefit/db/dao/WorkoutDao_Impl.kt"
+            line="261"
+            column="40"/>
+    </issue>
+
+    <issue
+        id="RestrictedApi"
+        message="SQLiteStatementUtil__StatementUtilKt.getColumnIndexOrThrow can only be called from within the same library group prefix (referenced groupId=`androidx.room` with prefix androidx from groupId=`LibreFit`)"
         errorLine1="        val _columnIndexOfTimeElapsed: Int = getColumnIndexOrThrow(_stmt, &quot;timeElapsed&quot;)"
         errorLine2="                                             ~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="build/generated/ksp/debug/kotlin/org/librefit/db/dao/WorkoutDao_Impl.kt"
-            line="260"
+            line="262"
             column="46"/>
     </issue>
 
@@ -6132,7 +6033,7 @@
         errorLine2="                                         ~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="build/generated/ksp/debug/kotlin/org/librefit/db/dao/WorkoutDao_Impl.kt"
-            line="261"
+            line="263"
             column="42"/>
     </issue>
 
@@ -6143,7 +6044,7 @@
         errorLine2="                                           ~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="build/generated/ksp/debug/kotlin/org/librefit/db/dao/WorkoutDao_Impl.kt"
-            line="262"
+            line="264"
             column="44"/>
     </issue>
 
@@ -6154,7 +6055,7 @@
         errorLine2="           ~~~~~~~~~~">
         <location
             file="build/generated/ksp/debug/kotlin/org/librefit/db/dao/WorkoutDao_Impl.kt"
-            line="316"
+            line="318"
             column="12"/>
     </issue>
 
@@ -6165,7 +6066,7 @@
         errorLine2="                                    ~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="build/generated/ksp/debug/kotlin/org/librefit/db/dao/WorkoutDao_Impl.kt"
-            line="321"
+            line="323"
             column="37"/>
     </issue>
 
@@ -6176,7 +6077,7 @@
         errorLine2="                                           ~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="build/generated/ksp/debug/kotlin/org/librefit/db/dao/WorkoutDao_Impl.kt"
-            line="322"
+            line="324"
             column="44"/>
     </issue>
 
@@ -6184,28 +6085,6 @@
         id="RestrictedApi"
         message="SQLiteStatementUtil__StatementUtilKt.getColumnIndexOrThrow can only be called from within the same library group prefix (referenced groupId=`androidx.room` with prefix androidx from groupId=`LibreFit`)"
         errorLine1="        val _columnIndexOfNotes: Int = getColumnIndexOrThrow(_stmt, &quot;notes&quot;)"
-        errorLine2="                                       ~~~~~~~~~~~~~~~~~~~~~">
-        <location
-            file="build/generated/ksp/debug/kotlin/org/librefit/db/dao/WorkoutDao_Impl.kt"
-            line="323"
-            column="40"/>
-    </issue>
-
-    <issue
-        id="RestrictedApi"
-        message="SQLiteStatementUtil__StatementUtilKt.getColumnIndexOrThrow can only be called from within the same library group prefix (referenced groupId=`androidx.room` with prefix androidx from groupId=`LibreFit`)"
-        errorLine1="        val _columnIndexOfTitle: Int = getColumnIndexOrThrow(_stmt, &quot;title&quot;)"
-        errorLine2="                                       ~~~~~~~~~~~~~~~~~~~~~">
-        <location
-            file="build/generated/ksp/debug/kotlin/org/librefit/db/dao/WorkoutDao_Impl.kt"
-            line="324"
-            column="40"/>
-    </issue>
-
-    <issue
-        id="RestrictedApi"
-        message="SQLiteStatementUtil__StatementUtilKt.getColumnIndexOrThrow can only be called from within the same library group prefix (referenced groupId=`androidx.room` with prefix androidx from groupId=`LibreFit`)"
-        errorLine1="        val _columnIndexOfState: Int = getColumnIndexOrThrow(_stmt, &quot;state&quot;)"
         errorLine2="                                       ~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="build/generated/ksp/debug/kotlin/org/librefit/db/dao/WorkoutDao_Impl.kt"
@@ -6216,11 +6095,33 @@
     <issue
         id="RestrictedApi"
         message="SQLiteStatementUtil__StatementUtilKt.getColumnIndexOrThrow can only be called from within the same library group prefix (referenced groupId=`androidx.room` with prefix androidx from groupId=`LibreFit`)"
+        errorLine1="        val _columnIndexOfTitle: Int = getColumnIndexOrThrow(_stmt, &quot;title&quot;)"
+        errorLine2="                                       ~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="build/generated/ksp/debug/kotlin/org/librefit/db/dao/WorkoutDao_Impl.kt"
+            line="326"
+            column="40"/>
+    </issue>
+
+    <issue
+        id="RestrictedApi"
+        message="SQLiteStatementUtil__StatementUtilKt.getColumnIndexOrThrow can only be called from within the same library group prefix (referenced groupId=`androidx.room` with prefix androidx from groupId=`LibreFit`)"
+        errorLine1="        val _columnIndexOfState: Int = getColumnIndexOrThrow(_stmt, &quot;state&quot;)"
+        errorLine2="                                       ~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="build/generated/ksp/debug/kotlin/org/librefit/db/dao/WorkoutDao_Impl.kt"
+            line="327"
+            column="40"/>
+    </issue>
+
+    <issue
+        id="RestrictedApi"
+        message="SQLiteStatementUtil__StatementUtilKt.getColumnIndexOrThrow can only be called from within the same library group prefix (referenced groupId=`androidx.room` with prefix androidx from groupId=`LibreFit`)"
         errorLine1="        val _columnIndexOfTimeElapsed: Int = getColumnIndexOrThrow(_stmt, &quot;timeElapsed&quot;)"
         errorLine2="                                             ~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="build/generated/ksp/debug/kotlin/org/librefit/db/dao/WorkoutDao_Impl.kt"
-            line="326"
+            line="328"
             column="46"/>
     </issue>
 
@@ -6231,7 +6132,7 @@
         errorLine2="                                         ~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="build/generated/ksp/debug/kotlin/org/librefit/db/dao/WorkoutDao_Impl.kt"
-            line="327"
+            line="329"
             column="42"/>
     </issue>
 
@@ -6242,7 +6143,7 @@
         errorLine2="                                           ~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="build/generated/ksp/debug/kotlin/org/librefit/db/dao/WorkoutDao_Impl.kt"
-            line="328"
+            line="330"
             column="44"/>
     </issue>
 
@@ -6253,7 +6154,7 @@
         errorLine2="           ~~~~~~~~~~">
         <location
             file="build/generated/ksp/debug/kotlin/org/librefit/db/dao/WorkoutDao_Impl.kt"
-            line="398"
+            line="400"
             column="12"/>
     </issue>
 
@@ -6264,7 +6165,7 @@
         errorLine2="                                    ~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="build/generated/ksp/debug/kotlin/org/librefit/db/dao/WorkoutDao_Impl.kt"
-            line="403"
+            line="405"
             column="37"/>
     </issue>
 
@@ -6275,7 +6176,7 @@
         errorLine2="                                           ~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="build/generated/ksp/debug/kotlin/org/librefit/db/dao/WorkoutDao_Impl.kt"
-            line="404"
+            line="406"
             column="44"/>
     </issue>
 
@@ -6283,28 +6184,6 @@
         id="RestrictedApi"
         message="SQLiteStatementUtil__StatementUtilKt.getColumnIndexOrThrow can only be called from within the same library group prefix (referenced groupId=`androidx.room` with prefix androidx from groupId=`LibreFit`)"
         errorLine1="        val _columnIndexOfNotes: Int = getColumnIndexOrThrow(_stmt, &quot;notes&quot;)"
-        errorLine2="                                       ~~~~~~~~~~~~~~~~~~~~~">
-        <location
-            file="build/generated/ksp/debug/kotlin/org/librefit/db/dao/WorkoutDao_Impl.kt"
-            line="405"
-            column="40"/>
-    </issue>
-
-    <issue
-        id="RestrictedApi"
-        message="SQLiteStatementUtil__StatementUtilKt.getColumnIndexOrThrow can only be called from within the same library group prefix (referenced groupId=`androidx.room` with prefix androidx from groupId=`LibreFit`)"
-        errorLine1="        val _columnIndexOfTitle: Int = getColumnIndexOrThrow(_stmt, &quot;title&quot;)"
-        errorLine2="                                       ~~~~~~~~~~~~~~~~~~~~~">
-        <location
-            file="build/generated/ksp/debug/kotlin/org/librefit/db/dao/WorkoutDao_Impl.kt"
-            line="406"
-            column="40"/>
-    </issue>
-
-    <issue
-        id="RestrictedApi"
-        message="SQLiteStatementUtil__StatementUtilKt.getColumnIndexOrThrow can only be called from within the same library group prefix (referenced groupId=`androidx.room` with prefix androidx from groupId=`LibreFit`)"
-        errorLine1="        val _columnIndexOfState: Int = getColumnIndexOrThrow(_stmt, &quot;state&quot;)"
         errorLine2="                                       ~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="build/generated/ksp/debug/kotlin/org/librefit/db/dao/WorkoutDao_Impl.kt"
@@ -6315,11 +6194,33 @@
     <issue
         id="RestrictedApi"
         message="SQLiteStatementUtil__StatementUtilKt.getColumnIndexOrThrow can only be called from within the same library group prefix (referenced groupId=`androidx.room` with prefix androidx from groupId=`LibreFit`)"
+        errorLine1="        val _columnIndexOfTitle: Int = getColumnIndexOrThrow(_stmt, &quot;title&quot;)"
+        errorLine2="                                       ~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="build/generated/ksp/debug/kotlin/org/librefit/db/dao/WorkoutDao_Impl.kt"
+            line="408"
+            column="40"/>
+    </issue>
+
+    <issue
+        id="RestrictedApi"
+        message="SQLiteStatementUtil__StatementUtilKt.getColumnIndexOrThrow can only be called from within the same library group prefix (referenced groupId=`androidx.room` with prefix androidx from groupId=`LibreFit`)"
+        errorLine1="        val _columnIndexOfState: Int = getColumnIndexOrThrow(_stmt, &quot;state&quot;)"
+        errorLine2="                                       ~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="build/generated/ksp/debug/kotlin/org/librefit/db/dao/WorkoutDao_Impl.kt"
+            line="409"
+            column="40"/>
+    </issue>
+
+    <issue
+        id="RestrictedApi"
+        message="SQLiteStatementUtil__StatementUtilKt.getColumnIndexOrThrow can only be called from within the same library group prefix (referenced groupId=`androidx.room` with prefix androidx from groupId=`LibreFit`)"
         errorLine1="        val _columnIndexOfTimeElapsed: Int = getColumnIndexOrThrow(_stmt, &quot;timeElapsed&quot;)"
         errorLine2="                                             ~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="build/generated/ksp/debug/kotlin/org/librefit/db/dao/WorkoutDao_Impl.kt"
-            line="408"
+            line="410"
             column="46"/>
     </issue>
 
@@ -6330,7 +6231,7 @@
         errorLine2="                                         ~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="build/generated/ksp/debug/kotlin/org/librefit/db/dao/WorkoutDao_Impl.kt"
-            line="409"
+            line="411"
             column="42"/>
     </issue>
 
@@ -6341,7 +6242,7 @@
         errorLine2="                                           ~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="build/generated/ksp/debug/kotlin/org/librefit/db/dao/WorkoutDao_Impl.kt"
-            line="410"
+            line="412"
             column="44"/>
     </issue>
 
@@ -6352,7 +6253,7 @@
         errorLine2="           ~~~~~~~~~~~~~~~~~">
         <location
             file="build/generated/ksp/debug/kotlin/org/librefit/db/dao/WorkoutDao_Impl.kt"
-            line="464"
+            line="466"
             column="12"/>
     </issue>
 
@@ -6363,7 +6264,7 @@
         errorLine2="                                    ~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="build/generated/ksp/debug/kotlin/org/librefit/db/dao/WorkoutDao_Impl.kt"
-            line="469"
+            line="471"
             column="37"/>
     </issue>
 
@@ -6374,7 +6275,7 @@
         errorLine2="                                           ~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="build/generated/ksp/debug/kotlin/org/librefit/db/dao/WorkoutDao_Impl.kt"
-            line="470"
+            line="472"
             column="44"/>
     </issue>
 
@@ -6382,28 +6283,6 @@
         id="RestrictedApi"
         message="SQLiteStatementUtil__StatementUtilKt.getColumnIndexOrThrow can only be called from within the same library group prefix (referenced groupId=`androidx.room` with prefix androidx from groupId=`LibreFit`)"
         errorLine1="        val _columnIndexOfNotes: Int = getColumnIndexOrThrow(_stmt, &quot;notes&quot;)"
-        errorLine2="                                       ~~~~~~~~~~~~~~~~~~~~~">
-        <location
-            file="build/generated/ksp/debug/kotlin/org/librefit/db/dao/WorkoutDao_Impl.kt"
-            line="471"
-            column="40"/>
-    </issue>
-
-    <issue
-        id="RestrictedApi"
-        message="SQLiteStatementUtil__StatementUtilKt.getColumnIndexOrThrow can only be called from within the same library group prefix (referenced groupId=`androidx.room` with prefix androidx from groupId=`LibreFit`)"
-        errorLine1="        val _columnIndexOfTitle: Int = getColumnIndexOrThrow(_stmt, &quot;title&quot;)"
-        errorLine2="                                       ~~~~~~~~~~~~~~~~~~~~~">
-        <location
-            file="build/generated/ksp/debug/kotlin/org/librefit/db/dao/WorkoutDao_Impl.kt"
-            line="472"
-            column="40"/>
-    </issue>
-
-    <issue
-        id="RestrictedApi"
-        message="SQLiteStatementUtil__StatementUtilKt.getColumnIndexOrThrow can only be called from within the same library group prefix (referenced groupId=`androidx.room` with prefix androidx from groupId=`LibreFit`)"
-        errorLine1="        val _columnIndexOfState: Int = getColumnIndexOrThrow(_stmt, &quot;state&quot;)"
         errorLine2="                                       ~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="build/generated/ksp/debug/kotlin/org/librefit/db/dao/WorkoutDao_Impl.kt"
@@ -6414,11 +6293,33 @@
     <issue
         id="RestrictedApi"
         message="SQLiteStatementUtil__StatementUtilKt.getColumnIndexOrThrow can only be called from within the same library group prefix (referenced groupId=`androidx.room` with prefix androidx from groupId=`LibreFit`)"
+        errorLine1="        val _columnIndexOfTitle: Int = getColumnIndexOrThrow(_stmt, &quot;title&quot;)"
+        errorLine2="                                       ~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="build/generated/ksp/debug/kotlin/org/librefit/db/dao/WorkoutDao_Impl.kt"
+            line="474"
+            column="40"/>
+    </issue>
+
+    <issue
+        id="RestrictedApi"
+        message="SQLiteStatementUtil__StatementUtilKt.getColumnIndexOrThrow can only be called from within the same library group prefix (referenced groupId=`androidx.room` with prefix androidx from groupId=`LibreFit`)"
+        errorLine1="        val _columnIndexOfState: Int = getColumnIndexOrThrow(_stmt, &quot;state&quot;)"
+        errorLine2="                                       ~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="build/generated/ksp/debug/kotlin/org/librefit/db/dao/WorkoutDao_Impl.kt"
+            line="475"
+            column="40"/>
+    </issue>
+
+    <issue
+        id="RestrictedApi"
+        message="SQLiteStatementUtil__StatementUtilKt.getColumnIndexOrThrow can only be called from within the same library group prefix (referenced groupId=`androidx.room` with prefix androidx from groupId=`LibreFit`)"
         errorLine1="        val _columnIndexOfTimeElapsed: Int = getColumnIndexOrThrow(_stmt, &quot;timeElapsed&quot;)"
         errorLine2="                                             ~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="build/generated/ksp/debug/kotlin/org/librefit/db/dao/WorkoutDao_Impl.kt"
-            line="474"
+            line="476"
             column="46"/>
     </issue>
 
@@ -6429,7 +6330,7 @@
         errorLine2="                                         ~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="build/generated/ksp/debug/kotlin/org/librefit/db/dao/WorkoutDao_Impl.kt"
-            line="475"
+            line="477"
             column="42"/>
     </issue>
 
@@ -6440,7 +6341,7 @@
         errorLine2="                                           ~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="build/generated/ksp/debug/kotlin/org/librefit/db/dao/WorkoutDao_Impl.kt"
-            line="476"
+            line="478"
             column="44"/>
     </issue>
 
@@ -6451,7 +6352,7 @@
         errorLine2="           ~~~~~~~~~~~~~~~~~">
         <location
             file="build/generated/ksp/debug/kotlin/org/librefit/db/dao/WorkoutDao_Impl.kt"
-            line="530"
+            line="532"
             column="12"/>
     </issue>
 
@@ -6462,7 +6363,7 @@
         errorLine2="                                    ~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="build/generated/ksp/debug/kotlin/org/librefit/db/dao/WorkoutDao_Impl.kt"
-            line="535"
+            line="537"
             column="37"/>
     </issue>
 
@@ -6473,7 +6374,7 @@
         errorLine2="                                           ~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="build/generated/ksp/debug/kotlin/org/librefit/db/dao/WorkoutDao_Impl.kt"
-            line="536"
+            line="538"
             column="44"/>
     </issue>
 
@@ -6481,28 +6382,6 @@
         id="RestrictedApi"
         message="SQLiteStatementUtil__StatementUtilKt.getColumnIndexOrThrow can only be called from within the same library group prefix (referenced groupId=`androidx.room` with prefix androidx from groupId=`LibreFit`)"
         errorLine1="        val _columnIndexOfNotes: Int = getColumnIndexOrThrow(_stmt, &quot;notes&quot;)"
-        errorLine2="                                       ~~~~~~~~~~~~~~~~~~~~~">
-        <location
-            file="build/generated/ksp/debug/kotlin/org/librefit/db/dao/WorkoutDao_Impl.kt"
-            line="537"
-            column="40"/>
-    </issue>
-
-    <issue
-        id="RestrictedApi"
-        message="SQLiteStatementUtil__StatementUtilKt.getColumnIndexOrThrow can only be called from within the same library group prefix (referenced groupId=`androidx.room` with prefix androidx from groupId=`LibreFit`)"
-        errorLine1="        val _columnIndexOfTitle: Int = getColumnIndexOrThrow(_stmt, &quot;title&quot;)"
-        errorLine2="                                       ~~~~~~~~~~~~~~~~~~~~~">
-        <location
-            file="build/generated/ksp/debug/kotlin/org/librefit/db/dao/WorkoutDao_Impl.kt"
-            line="538"
-            column="40"/>
-    </issue>
-
-    <issue
-        id="RestrictedApi"
-        message="SQLiteStatementUtil__StatementUtilKt.getColumnIndexOrThrow can only be called from within the same library group prefix (referenced groupId=`androidx.room` with prefix androidx from groupId=`LibreFit`)"
-        errorLine1="        val _columnIndexOfState: Int = getColumnIndexOrThrow(_stmt, &quot;state&quot;)"
         errorLine2="                                       ~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="build/generated/ksp/debug/kotlin/org/librefit/db/dao/WorkoutDao_Impl.kt"
@@ -6513,11 +6392,33 @@
     <issue
         id="RestrictedApi"
         message="SQLiteStatementUtil__StatementUtilKt.getColumnIndexOrThrow can only be called from within the same library group prefix (referenced groupId=`androidx.room` with prefix androidx from groupId=`LibreFit`)"
+        errorLine1="        val _columnIndexOfTitle: Int = getColumnIndexOrThrow(_stmt, &quot;title&quot;)"
+        errorLine2="                                       ~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="build/generated/ksp/debug/kotlin/org/librefit/db/dao/WorkoutDao_Impl.kt"
+            line="540"
+            column="40"/>
+    </issue>
+
+    <issue
+        id="RestrictedApi"
+        message="SQLiteStatementUtil__StatementUtilKt.getColumnIndexOrThrow can only be called from within the same library group prefix (referenced groupId=`androidx.room` with prefix androidx from groupId=`LibreFit`)"
+        errorLine1="        val _columnIndexOfState: Int = getColumnIndexOrThrow(_stmt, &quot;state&quot;)"
+        errorLine2="                                       ~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="build/generated/ksp/debug/kotlin/org/librefit/db/dao/WorkoutDao_Impl.kt"
+            line="541"
+            column="40"/>
+    </issue>
+
+    <issue
+        id="RestrictedApi"
+        message="SQLiteStatementUtil__StatementUtilKt.getColumnIndexOrThrow can only be called from within the same library group prefix (referenced groupId=`androidx.room` with prefix androidx from groupId=`LibreFit`)"
         errorLine1="        val _columnIndexOfTimeElapsed: Int = getColumnIndexOrThrow(_stmt, &quot;timeElapsed&quot;)"
         errorLine2="                                             ~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="build/generated/ksp/debug/kotlin/org/librefit/db/dao/WorkoutDao_Impl.kt"
-            line="540"
+            line="542"
             column="46"/>
     </issue>
 
@@ -6528,7 +6429,7 @@
         errorLine2="                                         ~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="build/generated/ksp/debug/kotlin/org/librefit/db/dao/WorkoutDao_Impl.kt"
-            line="541"
+            line="543"
             column="42"/>
     </issue>
 
@@ -6539,7 +6440,7 @@
         errorLine2="                                           ~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="build/generated/ksp/debug/kotlin/org/librefit/db/dao/WorkoutDao_Impl.kt"
-            line="542"
+            line="544"
             column="44"/>
     </issue>
 
@@ -6550,7 +6451,7 @@
         errorLine2="           ~~~~~~~~~~~~~~~~~">
         <location
             file="build/generated/ksp/debug/kotlin/org/librefit/db/dao/WorkoutDao_Impl.kt"
-            line="612"
+            line="614"
             column="12"/>
     </issue>
 
@@ -6561,7 +6462,7 @@
         errorLine2="                                    ~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="build/generated/ksp/debug/kotlin/org/librefit/db/dao/WorkoutDao_Impl.kt"
-            line="619"
+            line="621"
             column="37"/>
     </issue>
 
@@ -6572,7 +6473,7 @@
         errorLine2="                                           ~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="build/generated/ksp/debug/kotlin/org/librefit/db/dao/WorkoutDao_Impl.kt"
-            line="620"
+            line="622"
             column="44"/>
     </issue>
 
@@ -6580,28 +6481,6 @@
         id="RestrictedApi"
         message="SQLiteStatementUtil__StatementUtilKt.getColumnIndexOrThrow can only be called from within the same library group prefix (referenced groupId=`androidx.room` with prefix androidx from groupId=`LibreFit`)"
         errorLine1="        val _columnIndexOfNotes: Int = getColumnIndexOrThrow(_stmt, &quot;notes&quot;)"
-        errorLine2="                                       ~~~~~~~~~~~~~~~~~~~~~">
-        <location
-            file="build/generated/ksp/debug/kotlin/org/librefit/db/dao/WorkoutDao_Impl.kt"
-            line="621"
-            column="40"/>
-    </issue>
-
-    <issue
-        id="RestrictedApi"
-        message="SQLiteStatementUtil__StatementUtilKt.getColumnIndexOrThrow can only be called from within the same library group prefix (referenced groupId=`androidx.room` with prefix androidx from groupId=`LibreFit`)"
-        errorLine1="        val _columnIndexOfTitle: Int = getColumnIndexOrThrow(_stmt, &quot;title&quot;)"
-        errorLine2="                                       ~~~~~~~~~~~~~~~~~~~~~">
-        <location
-            file="build/generated/ksp/debug/kotlin/org/librefit/db/dao/WorkoutDao_Impl.kt"
-            line="622"
-            column="40"/>
-    </issue>
-
-    <issue
-        id="RestrictedApi"
-        message="SQLiteStatementUtil__StatementUtilKt.getColumnIndexOrThrow can only be called from within the same library group prefix (referenced groupId=`androidx.room` with prefix androidx from groupId=`LibreFit`)"
-        errorLine1="        val _columnIndexOfState: Int = getColumnIndexOrThrow(_stmt, &quot;state&quot;)"
         errorLine2="                                       ~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="build/generated/ksp/debug/kotlin/org/librefit/db/dao/WorkoutDao_Impl.kt"
@@ -6612,11 +6491,33 @@
     <issue
         id="RestrictedApi"
         message="SQLiteStatementUtil__StatementUtilKt.getColumnIndexOrThrow can only be called from within the same library group prefix (referenced groupId=`androidx.room` with prefix androidx from groupId=`LibreFit`)"
+        errorLine1="        val _columnIndexOfTitle: Int = getColumnIndexOrThrow(_stmt, &quot;title&quot;)"
+        errorLine2="                                       ~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="build/generated/ksp/debug/kotlin/org/librefit/db/dao/WorkoutDao_Impl.kt"
+            line="624"
+            column="40"/>
+    </issue>
+
+    <issue
+        id="RestrictedApi"
+        message="SQLiteStatementUtil__StatementUtilKt.getColumnIndexOrThrow can only be called from within the same library group prefix (referenced groupId=`androidx.room` with prefix androidx from groupId=`LibreFit`)"
+        errorLine1="        val _columnIndexOfState: Int = getColumnIndexOrThrow(_stmt, &quot;state&quot;)"
+        errorLine2="                                       ~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="build/generated/ksp/debug/kotlin/org/librefit/db/dao/WorkoutDao_Impl.kt"
+            line="625"
+            column="40"/>
+    </issue>
+
+    <issue
+        id="RestrictedApi"
+        message="SQLiteStatementUtil__StatementUtilKt.getColumnIndexOrThrow can only be called from within the same library group prefix (referenced groupId=`androidx.room` with prefix androidx from groupId=`LibreFit`)"
         errorLine1="        val _columnIndexOfTimeElapsed: Int = getColumnIndexOrThrow(_stmt, &quot;timeElapsed&quot;)"
         errorLine2="                                             ~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="build/generated/ksp/debug/kotlin/org/librefit/db/dao/WorkoutDao_Impl.kt"
-            line="624"
+            line="626"
             column="46"/>
     </issue>
 
@@ -6627,7 +6528,7 @@
         errorLine2="                                         ~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="build/generated/ksp/debug/kotlin/org/librefit/db/dao/WorkoutDao_Impl.kt"
-            line="625"
+            line="627"
             column="42"/>
     </issue>
 
@@ -6638,7 +6539,7 @@
         errorLine2="                                           ~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="build/generated/ksp/debug/kotlin/org/librefit/db/dao/WorkoutDao_Impl.kt"
-            line="626"
+            line="628"
             column="44"/>
     </issue>
 
@@ -6649,7 +6550,7 @@
         errorLine2="           ~~~~~~~~~~">
         <location
             file="build/generated/ksp/debug/kotlin/org/librefit/db/dao/WorkoutDao_Impl.kt"
-            line="680"
+            line="682"
             column="12"/>
     </issue>
 
@@ -6660,7 +6561,7 @@
         errorLine2="                                    ~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="build/generated/ksp/debug/kotlin/org/librefit/db/dao/WorkoutDao_Impl.kt"
-            line="685"
+            line="687"
             column="37"/>
     </issue>
 
@@ -6671,7 +6572,7 @@
         errorLine2="                                           ~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="build/generated/ksp/debug/kotlin/org/librefit/db/dao/WorkoutDao_Impl.kt"
-            line="686"
+            line="688"
             column="44"/>
     </issue>
 
@@ -6679,28 +6580,6 @@
         id="RestrictedApi"
         message="SQLiteStatementUtil__StatementUtilKt.getColumnIndexOrThrow can only be called from within the same library group prefix (referenced groupId=`androidx.room` with prefix androidx from groupId=`LibreFit`)"
         errorLine1="        val _columnIndexOfNotes: Int = getColumnIndexOrThrow(_stmt, &quot;notes&quot;)"
-        errorLine2="                                       ~~~~~~~~~~~~~~~~~~~~~">
-        <location
-            file="build/generated/ksp/debug/kotlin/org/librefit/db/dao/WorkoutDao_Impl.kt"
-            line="687"
-            column="40"/>
-    </issue>
-
-    <issue
-        id="RestrictedApi"
-        message="SQLiteStatementUtil__StatementUtilKt.getColumnIndexOrThrow can only be called from within the same library group prefix (referenced groupId=`androidx.room` with prefix androidx from groupId=`LibreFit`)"
-        errorLine1="        val _columnIndexOfTitle: Int = getColumnIndexOrThrow(_stmt, &quot;title&quot;)"
-        errorLine2="                                       ~~~~~~~~~~~~~~~~~~~~~">
-        <location
-            file="build/generated/ksp/debug/kotlin/org/librefit/db/dao/WorkoutDao_Impl.kt"
-            line="688"
-            column="40"/>
-    </issue>
-
-    <issue
-        id="RestrictedApi"
-        message="SQLiteStatementUtil__StatementUtilKt.getColumnIndexOrThrow can only be called from within the same library group prefix (referenced groupId=`androidx.room` with prefix androidx from groupId=`LibreFit`)"
-        errorLine1="        val _columnIndexOfState: Int = getColumnIndexOrThrow(_stmt, &quot;state&quot;)"
         errorLine2="                                       ~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="build/generated/ksp/debug/kotlin/org/librefit/db/dao/WorkoutDao_Impl.kt"
@@ -6711,11 +6590,33 @@
     <issue
         id="RestrictedApi"
         message="SQLiteStatementUtil__StatementUtilKt.getColumnIndexOrThrow can only be called from within the same library group prefix (referenced groupId=`androidx.room` with prefix androidx from groupId=`LibreFit`)"
+        errorLine1="        val _columnIndexOfTitle: Int = getColumnIndexOrThrow(_stmt, &quot;title&quot;)"
+        errorLine2="                                       ~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="build/generated/ksp/debug/kotlin/org/librefit/db/dao/WorkoutDao_Impl.kt"
+            line="690"
+            column="40"/>
+    </issue>
+
+    <issue
+        id="RestrictedApi"
+        message="SQLiteStatementUtil__StatementUtilKt.getColumnIndexOrThrow can only be called from within the same library group prefix (referenced groupId=`androidx.room` with prefix androidx from groupId=`LibreFit`)"
+        errorLine1="        val _columnIndexOfState: Int = getColumnIndexOrThrow(_stmt, &quot;state&quot;)"
+        errorLine2="                                       ~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="build/generated/ksp/debug/kotlin/org/librefit/db/dao/WorkoutDao_Impl.kt"
+            line="691"
+            column="40"/>
+    </issue>
+
+    <issue
+        id="RestrictedApi"
+        message="SQLiteStatementUtil__StatementUtilKt.getColumnIndexOrThrow can only be called from within the same library group prefix (referenced groupId=`androidx.room` with prefix androidx from groupId=`LibreFit`)"
         errorLine1="        val _columnIndexOfTimeElapsed: Int = getColumnIndexOrThrow(_stmt, &quot;timeElapsed&quot;)"
         errorLine2="                                             ~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="build/generated/ksp/debug/kotlin/org/librefit/db/dao/WorkoutDao_Impl.kt"
-            line="690"
+            line="692"
             column="46"/>
     </issue>
 
@@ -6726,7 +6627,7 @@
         errorLine2="                                         ~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="build/generated/ksp/debug/kotlin/org/librefit/db/dao/WorkoutDao_Impl.kt"
-            line="691"
+            line="693"
             column="42"/>
     </issue>
 
@@ -6737,7 +6638,7 @@
         errorLine2="                                           ~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="build/generated/ksp/debug/kotlin/org/librefit/db/dao/WorkoutDao_Impl.kt"
-            line="692"
+            line="694"
             column="44"/>
     </issue>
 
@@ -6748,7 +6649,7 @@
         errorLine2="           ~~~~~~~~~~~~~~~~~">
         <location
             file="build/generated/ksp/debug/kotlin/org/librefit/db/dao/WorkoutDao_Impl.kt"
-            line="762"
+            line="764"
             column="12"/>
     </issue>
 
@@ -6759,7 +6660,7 @@
         errorLine2="                                    ~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="build/generated/ksp/debug/kotlin/org/librefit/db/dao/WorkoutDao_Impl.kt"
-            line="767"
+            line="769"
             column="37"/>
     </issue>
 
@@ -6770,7 +6671,7 @@
         errorLine2="                                              ~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="build/generated/ksp/debug/kotlin/org/librefit/db/dao/WorkoutDao_Impl.kt"
-            line="768"
+            line="770"
             column="47"/>
     </issue>
 
@@ -6781,7 +6682,7 @@
         errorLine2="                                       ~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="build/generated/ksp/debug/kotlin/org/librefit/db/dao/WorkoutDao_Impl.kt"
-            line="769"
+            line="771"
             column="40"/>
     </issue>
 
@@ -6792,7 +6693,7 @@
         errorLine2="                                         ~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="build/generated/ksp/debug/kotlin/org/librefit/db/dao/WorkoutDao_Impl.kt"
-            line="770"
+            line="772"
             column="42"/>
     </issue>
 
@@ -6803,7 +6704,15 @@
         errorLine2="                                          ~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="build/generated/ksp/debug/kotlin/org/librefit/db/dao/WorkoutDao_Impl.kt"
-            line="771"
+            column="43" line="773" />
+    </issue>
+
+    <issue errorLine1="        val _columnIndexOfPosition: Int = getColumnIndexOrThrow(_stmt, &quot;position&quot;)"
+        errorLine2="                                          ~~~~~~~~~~~~~~~~~~~~~"
+        id="RestrictedApi"
+        message="SQLiteStatementUtil__StatementUtilKt.getColumnIndexOrThrow can only be called from within the same library group prefix (referenced groupId=`androidx.room` with prefix androidx from groupId=`LibreFit`)">
+        <location file="build/generated/ksp/debug/kotlin/org/librefit/db/dao/WorkoutDao_Impl.kt"
+            line="774"
             column="43"/>
     </issue>
 
@@ -6814,7 +6723,7 @@
         errorLine2="                                           ~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="build/generated/ksp/debug/kotlin/org/librefit/db/dao/WorkoutDao_Impl.kt"
-            line="772"
+            line="775"
             column="44"/>
     </issue>
 
@@ -6825,7 +6734,7 @@
         errorLine2="           ~~~~~~~~~~~~~~~~~">
         <location
             file="build/generated/ksp/debug/kotlin/org/librefit/db/dao/WorkoutDao_Impl.kt"
-            line="828"
+            line="833"
             column="12"/>
     </issue>
 
@@ -6836,7 +6745,7 @@
         errorLine2="                                    ~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="build/generated/ksp/debug/kotlin/org/librefit/db/dao/WorkoutDao_Impl.kt"
-            line="833"
+            line="838"
             column="37"/>
     </issue>
 
@@ -6847,7 +6756,7 @@
         errorLine2="                                      ~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="build/generated/ksp/debug/kotlin/org/librefit/db/dao/WorkoutDao_Impl.kt"
-            line="834"
+            line="839"
             column="39"/>
     </issue>
 
@@ -6858,7 +6767,7 @@
         errorLine2="                                      ~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="build/generated/ksp/debug/kotlin/org/librefit/db/dao/WorkoutDao_Impl.kt"
-            line="835"
+            line="840"
             column="39"/>
     </issue>
 
@@ -6869,7 +6778,7 @@
         errorLine2="                                             ~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="build/generated/ksp/debug/kotlin/org/librefit/db/dao/WorkoutDao_Impl.kt"
-            line="836"
+            line="841"
             column="46"/>
     </issue>
 
@@ -6880,7 +6789,7 @@
         errorLine2="                                           ~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="build/generated/ksp/debug/kotlin/org/librefit/db/dao/WorkoutDao_Impl.kt"
-            line="837"
+            line="842"
             column="44"/>
     </issue>
 
@@ -6891,7 +6800,7 @@
         errorLine2="                                            ~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="build/generated/ksp/debug/kotlin/org/librefit/db/dao/WorkoutDao_Impl.kt"
-            line="838"
+            line="843"
             column="45"/>
     </issue>
 
@@ -6902,7 +6811,7 @@
         errorLine2="           ~~~~~~~~~~~~~~~~~">
         <location
             file="build/generated/ksp/debug/kotlin/org/librefit/db/dao/WorkoutDao_Impl.kt"
-            line="868"
+            line="873"
             column="12"/>
     </issue>
 
@@ -6913,7 +6822,7 @@
         errorLine2="                                    ~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="build/generated/ksp/debug/kotlin/org/librefit/db/dao/WorkoutDao_Impl.kt"
-            line="875"
+            line="880"
             column="37"/>
     </issue>
 
@@ -6924,7 +6833,7 @@
         errorLine2="                                           ~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="build/generated/ksp/debug/kotlin/org/librefit/db/dao/WorkoutDao_Impl.kt"
-            line="876"
+            line="881"
             column="44"/>
     </issue>
 
@@ -6935,7 +6844,7 @@
         errorLine2="                                       ~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="build/generated/ksp/debug/kotlin/org/librefit/db/dao/WorkoutDao_Impl.kt"
-            line="877"
+            line="882"
             column="40"/>
     </issue>
 
@@ -6946,7 +6855,7 @@
         errorLine2="                                       ~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="build/generated/ksp/debug/kotlin/org/librefit/db/dao/WorkoutDao_Impl.kt"
-            line="878"
+            line="883"
             column="40"/>
     </issue>
 
@@ -6957,7 +6866,7 @@
         errorLine2="                                       ~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="build/generated/ksp/debug/kotlin/org/librefit/db/dao/WorkoutDao_Impl.kt"
-            line="879"
+            line="884"
             column="40"/>
     </issue>
 
@@ -6968,7 +6877,7 @@
         errorLine2="                                             ~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="build/generated/ksp/debug/kotlin/org/librefit/db/dao/WorkoutDao_Impl.kt"
-            line="880"
+            line="885"
             column="46"/>
     </issue>
 
@@ -6979,7 +6888,7 @@
         errorLine2="                                         ~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="build/generated/ksp/debug/kotlin/org/librefit/db/dao/WorkoutDao_Impl.kt"
-            line="881"
+            line="886"
             column="42"/>
     </issue>
 
@@ -6990,7 +6899,7 @@
         errorLine2="                                           ~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="build/generated/ksp/debug/kotlin/org/librefit/db/dao/WorkoutDao_Impl.kt"
-            line="882"
+            line="887"
             column="44"/>
     </issue>
 
@@ -7001,7 +6910,7 @@
         errorLine2="           ~~~~~~~~~~">
         <location
             file="build/generated/ksp/debug/kotlin/org/librefit/db/dao/WorkoutDao_Impl.kt"
-            line="959"
+            line="964"
             column="12"/>
     </issue>
 
@@ -7012,7 +6921,7 @@
         errorLine2="                                    ~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="build/generated/ksp/debug/kotlin/org/librefit/db/dao/WorkoutDao_Impl.kt"
-            line="966"
+            line="971"
             column="37"/>
     </issue>
 
@@ -7023,7 +6932,7 @@
         errorLine2="                                           ~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="build/generated/ksp/debug/kotlin/org/librefit/db/dao/WorkoutDao_Impl.kt"
-            line="967"
+            line="972"
             column="44"/>
     </issue>
 
@@ -7034,7 +6943,7 @@
         errorLine2="                                       ~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="build/generated/ksp/debug/kotlin/org/librefit/db/dao/WorkoutDao_Impl.kt"
-            line="968"
+            line="973"
             column="40"/>
     </issue>
 
@@ -7045,7 +6954,7 @@
         errorLine2="                                       ~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="build/generated/ksp/debug/kotlin/org/librefit/db/dao/WorkoutDao_Impl.kt"
-            line="969"
+            line="974"
             column="40"/>
     </issue>
 
@@ -7056,7 +6965,7 @@
         errorLine2="                                       ~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="build/generated/ksp/debug/kotlin/org/librefit/db/dao/WorkoutDao_Impl.kt"
-            line="970"
+            line="975"
             column="40"/>
     </issue>
 
@@ -7067,7 +6976,7 @@
         errorLine2="                                             ~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="build/generated/ksp/debug/kotlin/org/librefit/db/dao/WorkoutDao_Impl.kt"
-            line="971"
+            line="976"
             column="46"/>
     </issue>
 
@@ -7078,7 +6987,7 @@
         errorLine2="                                         ~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="build/generated/ksp/debug/kotlin/org/librefit/db/dao/WorkoutDao_Impl.kt"
-            line="972"
+            line="977"
             column="42"/>
     </issue>
 
@@ -7089,7 +6998,7 @@
         errorLine2="                                           ~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="build/generated/ksp/debug/kotlin/org/librefit/db/dao/WorkoutDao_Impl.kt"
-            line="973"
+            line="978"
             column="44"/>
     </issue>
 
@@ -7100,7 +7009,7 @@
         errorLine2="      ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="build/generated/ksp/debug/kotlin/org/librefit/db/dao/WorkoutDao_Impl.kt"
-            line="1070"
+            line="1075"
             column="7"/>
     </issue>
 
@@ -7111,7 +7020,7 @@
         errorLine2="    ~~~~~~~~~~~~~~~~~~">
         <location
             file="build/generated/ksp/debug/kotlin/org/librefit/db/dao/WorkoutDao_Impl.kt"
-            line="1078"
+            line="1083"
             column="5"/>
     </issue>
 
@@ -7122,7 +7031,7 @@
         errorLine2="                       ~~~~~~~~~~~~~~">
         <location
             file="build/generated/ksp/debug/kotlin/org/librefit/db/dao/WorkoutDao_Impl.kt"
-            line="1078"
+            line="1083"
             column="24"/>
     </issue>
 
@@ -7133,7 +7042,7 @@
         errorLine2="                               ~~~~~~~~~~~~~~">
         <location
             file="build/generated/ksp/debug/kotlin/org/librefit/db/dao/WorkoutDao_Impl.kt"
-            line="1089"
+            line="1094"
             column="32"/>
     </issue>
 
@@ -7144,7 +7053,7 @@
         errorLine2="      ~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="build/generated/ksp/debug/kotlin/org/librefit/db/dao/WorkoutDao_Impl.kt"
-            line="1134"
+            line="1139"
             column="7"/>
     </issue>
 
@@ -7155,7 +7064,7 @@
         errorLine2="    ~~~~~~~~~~~~~~~~~~">
         <location
             file="build/generated/ksp/debug/kotlin/org/librefit/db/dao/WorkoutDao_Impl.kt"
-            line="1142"
+            line="1147"
             column="5"/>
     </issue>
 
@@ -7166,7 +7075,7 @@
         errorLine2="                       ~~~~~~~~~~~~~~">
         <location
             file="build/generated/ksp/debug/kotlin/org/librefit/db/dao/WorkoutDao_Impl.kt"
-            line="1142"
+            line="1147"
             column="24"/>
     </issue>
 
@@ -7177,7 +7086,7 @@
         errorLine2="                               ~~~~~~~~~~~~~~">
         <location
             file="build/generated/ksp/debug/kotlin/org/librefit/db/dao/WorkoutDao_Impl.kt"
-            line="1152"
+            line="1157"
             column="32"/>
     </issue>
 
@@ -7188,7 +7097,7 @@
         errorLine2="      ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="build/generated/ksp/debug/kotlin/org/librefit/db/dao/WorkoutDao_Impl.kt"
-            line="1251"
+            line="1256"
             column="7"/>
     </issue>
 
@@ -7199,7 +7108,7 @@
         errorLine2="    ~~~~~~~~~~~~~~~~~~">
         <location
             file="build/generated/ksp/debug/kotlin/org/librefit/db/dao/WorkoutDao_Impl.kt"
-            line="1259"
+            line="1264"
             column="5"/>
     </issue>
 
@@ -7210,7 +7119,7 @@
         errorLine2="                       ~~~~~~~~~~~~~~">
         <location
             file="build/generated/ksp/debug/kotlin/org/librefit/db/dao/WorkoutDao_Impl.kt"
-            line="1259"
+            line="1264"
             column="24"/>
     </issue>
 
@@ -7221,7 +7130,7 @@
         errorLine2="                               ~~~~~~~~~~~~~~">
         <location
             file="build/generated/ksp/debug/kotlin/org/librefit/db/dao/WorkoutDao_Impl.kt"
-            line="1270"
+            line="1275"
             column="32"/>
     </issue>
 
@@ -8468,6 +8377,12 @@
             column="12"/>
     </issue>
 
+    <issue errorLine1="&lt;vector xmlns:android=&quot;http://schemas.android.com/apk/res/android&quot;" errorLine2="^"
+        id="UnusedResources"
+        message="The resource `R.drawable.ic_barbell` appears to be unused">
+        <location column="1" file="src/main/res/drawable/ic_barbell.xml" line="1" />
+    </issue>
+
     <issue
         id="UnusedResources"
         message="The resource `R.drawable.ic_keyboard_double_arrow_up` appears to be unused"
@@ -8558,8 +8473,7 @@
         errorLine1="    &lt;string name=&quot;load_only&quot;>Load only&lt;/string>"
         errorLine2="            ~~~~~~~~~~~~~~~~">
         <location
-            file="src/main/res/values/strings.xml"
-            line="80"
+            file="src/main/res/values/strings.xml" line="86"
             column="13"/>
     </issue>
 
@@ -8569,8 +8483,7 @@
         errorLine1="    &lt;string name=&quot;quit_workout_question&quot;>Quit workout?&lt;/string>"
         errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
-            file="src/main/res/values/strings.xml"
-            line="207"
+            file="src/main/res/values/strings.xml" line="215"
             column="13"/>
     </issue>
 
@@ -8580,8 +8493,7 @@
         errorLine1="    &lt;string name=&quot;quit_workout_text&quot;>Are you sure you want to quit? Your workout won\&apos;t be saved&lt;/string>"
         errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
-            file="src/main/res/values/strings.xml"
-            line="208"
+            file="src/main/res/values/strings.xml" line="216"
             column="13"/>
     </issue>
 
@@ -8591,8 +8503,7 @@
         errorLine1="    &lt;string name=&quot;new_workout&quot;>New workout&lt;/string>"
         errorLine2="            ~~~~~~~~~~~~~~~~~~">
         <location
-            file="src/main/res/values/strings.xml"
-            line="213"
+            file="src/main/res/values/strings.xml" line="221"
             column="13"/>
     </issue>
 
@@ -8602,8 +8513,14 @@
         errorLine1="    &lt;string name=&quot;language_english&quot;>English&lt;/string>"
         errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~">
         <location
-            file="src/main/res/values/strings.xml"
-            line="232"
+            column="13" file="src/main/res/values/strings.xml" line="240" />
+    </issue>
+
+    <issue errorLine1="    &lt;string name=&quot;language_italian&quot;>Italian&lt;/string>"
+        errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~"
+        id="UnusedResources"
+        message="The resource `R.string.language_italian` appears to be unused">
+        <location file="src/main/res/values/strings.xml" line="242"
             column="13"/>
     </issue>
 
@@ -8613,8 +8530,7 @@
         errorLine1="    &lt;string name=&quot;past&quot;>Past&lt;/string>"
         errorLine2="            ~~~~~~~~~~~">
         <location
-            file="src/main/res/values/strings.xml"
-            line="244"
+            file="src/main/res/values/strings.xml" line="256"
             column="13"/>
     </issue>
 
@@ -8624,8 +8540,7 @@
         errorLine1="    &lt;string name=&quot;day&quot;>Day&lt;/string>"
         errorLine2="            ~~~~~~~~~~">
         <location
-            file="src/main/res/values/strings.xml"
-            line="248"
+            file="src/main/res/values/strings.xml" line="260"
             column="13"/>
     </issue>
 
@@ -8635,8 +8550,7 @@
         errorLine1="    &lt;string name=&quot;month&quot;>Month&lt;/string>"
         errorLine2="            ~~~~~~~~~~~~">
         <location
-            file="src/main/res/values/strings.xml"
-            line="250"
+            file="src/main/res/values/strings.xml" line="262"
             column="13"/>
     </issue>
 
@@ -8646,8 +8560,7 @@
         errorLine1="    &lt;string name=&quot;years&quot;>Years&lt;/string>"
         errorLine2="            ~~~~~~~~~~~~">
         <location
-            file="src/main/res/values/strings.xml"
-            line="253"
+            file="src/main/res/values/strings.xml" line="265"
             column="13"/>
     </issue>
 
@@ -8657,8 +8570,7 @@
         errorLine1="    &lt;string name=&quot;companion_app_desc&quot;>Just install the companion app and click the button below.&lt;/string>"
         errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
-            file="src/main/res/values/strings.xml"
-            line="266"
+            file="src/main/res/values/strings.xml" line="278"
             column="13"/>
     </issue>
 
@@ -8668,8 +8580,7 @@
         errorLine1="    &lt;string name=&quot;verify_companion_app&quot;>Verify companion app&lt;/string>"
         errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
-            file="src/main/res/values/strings.xml"
-            line="268"
+            file="src/main/res/values/strings.xml" line="280"
             column="13"/>
     </issue>
 
@@ -8679,8 +8590,7 @@
         errorLine1="    &lt;string name=&quot;status&quot;>Status&lt;/string>"
         errorLine2="            ~~~~~~~~~~~~~">
         <location
-            file="src/main/res/values/strings.xml"
-            line="269"
+            file="src/main/res/values/strings.xml" line="281"
             column="13"/>
     </issue>
 
@@ -8690,8 +8600,7 @@
         errorLine1="    &lt;string name=&quot;verify_companion_or_code&quot;>Verify or the companion app or the code.&lt;/string>"
         errorLine2="            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
-            file="src/main/res/values/strings.xml"
-            line="273"
+            file="src/main/res/values/strings.xml" line="285"
             column="13"/>
     </issue>
 
@@ -8701,8 +8610,7 @@
         errorLine1="    &lt;string name=&quot;others&quot;>Others&lt;/string>"
         errorLine2="            ~~~~~~~~~~~~~">
         <location
-            file="src/main/res/values/strings.xml"
-            line="437"
+            file="src/main/res/values/strings.xml" line="451"
             column="13"/>
     </issue>
 
@@ -8764,21 +8672,21 @@
 
     <issue
         id="IconDensities"
-        message="Missing the following drawables in `drawable-hdpi`: tut_complete_workout_1.webp, tut_complete_workout_2.webp, tut_complete_workout_3.webp, tut_complete_workout_4.webp, tut_complete_workout_5.webp... (6 more)">
+        message="Missing the following drawables in `drawable-hdpi`: altered_deal.png, tut_complete_workout_1.webp, tut_complete_workout_2.webp, tut_complete_workout_3.webp, tut_complete_workout_4.webp... (7 more)">
         <location
             file="src/main/res/drawable-hdpi"/>
     </issue>
 
     <issue
         id="IconDensities"
-        message="Missing the following drawables in `drawable-mdpi`: tut_complete_workout_1.webp, tut_complete_workout_2.webp, tut_complete_workout_3.webp, tut_complete_workout_4.webp, tut_complete_workout_5.webp... (6 more)">
+        message="Missing the following drawables in `drawable-mdpi`: altered_deal.png, tut_complete_workout_1.webp, tut_complete_workout_2.webp, tut_complete_workout_3.webp, tut_complete_workout_4.webp... (7 more)">
         <location
             file="src/main/res/drawable-mdpi"/>
     </issue>
 
     <issue
         id="IconDensities"
-        message="Missing the following drawables in `drawable-xhdpi`: tut_complete_workout_1.webp, tut_complete_workout_2.webp, tut_complete_workout_3.webp, tut_complete_workout_4.webp, tut_complete_workout_5.webp... (6 more)">
+        message="Missing the following drawables in `drawable-xhdpi`: altered_deal.png, tut_complete_workout_1.webp, tut_complete_workout_2.webp, tut_complete_workout_3.webp, tut_complete_workout_4.webp... (7 more)">
         <location
             file="src/main/res/drawable-xhdpi"/>
     </issue>

--- a/app/schemas/org.librefit.db.AppDatabase/3.json
+++ b/app/schemas/org.librefit.db.AppDatabase/3.json
@@ -1,0 +1,382 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 3,
+    "identityHash": "8e973c578ef7f482bf8261f8db8abc6d",
+    "entities": [
+      {
+        "tableName": "workouts",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `routineId` INTEGER NOT NULL, `notes` TEXT NOT NULL, `title` TEXT NOT NULL, `state` TEXT NOT NULL, `timeElapsed` INTEGER NOT NULL, `created` TEXT NOT NULL, `completed` TEXT NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "routineId",
+            "columnName": "routineId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "notes",
+            "columnName": "notes",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "state",
+            "columnName": "state",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "timeElapsed",
+            "columnName": "timeElapsed",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "created",
+            "columnName": "created",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "completed",
+            "columnName": "completed",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "exercises",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `idExerciseDC` TEXT NOT NULL, `notes` TEXT NOT NULL, `setMode` TEXT NOT NULL, `restTime` INTEGER NOT NULL, `position` INTEGER NOT NULL, `workoutId` INTEGER NOT NULL, FOREIGN KEY(`workoutId`) REFERENCES `workouts`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE , FOREIGN KEY(`idExerciseDC`) REFERENCES `dataset`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "idExerciseDC",
+            "columnName": "idExerciseDC",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "notes",
+            "columnName": "notes",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "setMode",
+            "columnName": "setMode",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "restTime",
+            "columnName": "restTime",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "position",
+            "columnName": "position",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "workoutId",
+            "columnName": "workoutId",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_exercises_workoutId",
+            "unique": false,
+            "columnNames": [
+              "workoutId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_exercises_workoutId` ON `${TABLE_NAME}` (`workoutId`)"
+          },
+          {
+            "name": "index_exercises_workoutId_position",
+            "unique": false,
+            "columnNames": [
+              "workoutId",
+              "position"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_exercises_workoutId_position` ON `${TABLE_NAME}` (`workoutId`, `position`)"
+          },
+          {
+            "name": "index_exercises_idExerciseDC",
+            "unique": false,
+            "columnNames": [
+              "idExerciseDC"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_exercises_idExerciseDC` ON `${TABLE_NAME}` (`idExerciseDC`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "workouts",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "workoutId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          },
+          {
+            "table": "dataset",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "idExerciseDC"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "sets",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `load` REAL NOT NULL, `reps` INTEGER NOT NULL, `elapsedTime` INTEGER NOT NULL, `completed` INTEGER NOT NULL, `exerciseId` INTEGER NOT NULL, FOREIGN KEY(`exerciseId`) REFERENCES `exercises`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "load",
+            "columnName": "load",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "reps",
+            "columnName": "reps",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "elapsedTime",
+            "columnName": "elapsedTime",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "completed",
+            "columnName": "completed",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "exerciseId",
+            "columnName": "exerciseId",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_sets_exerciseId",
+            "unique": false,
+            "columnNames": [
+              "exerciseId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_sets_exerciseId` ON `${TABLE_NAME}` (`exerciseId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "exercises",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "exerciseId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "measurements",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `bodyWeight` REAL NOT NULL, `bodyFatPercentage` INTEGER NOT NULL, `muscleMassPercentage` INTEGER NOT NULL, `date` TEXT NOT NULL, `notes` TEXT NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "bodyWeight",
+            "columnName": "bodyWeight",
+            "affinity": "REAL",
+            "notNull": true
+          },
+          {
+            "fieldPath": "bodyFatPercentage",
+            "columnName": "bodyFatPercentage",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "muscleMassPercentage",
+            "columnName": "muscleMassPercentage",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "date",
+            "columnName": "date",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "notes",
+            "columnName": "notes",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "dataset",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `name` TEXT NOT NULL, `force` TEXT, `level` TEXT NOT NULL, `mechanic` TEXT, `equipment` TEXT, `primaryMuscles` TEXT NOT NULL, `secondaryMuscles` TEXT NOT NULL, `instructions` TEXT NOT NULL, `category` TEXT NOT NULL, `images` TEXT NOT NULL, `isCustomExercise` INTEGER NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "force",
+            "columnName": "force",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "level",
+            "columnName": "level",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "mechanic",
+            "columnName": "mechanic",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "equipment",
+            "columnName": "equipment",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "primaryMuscles",
+            "columnName": "primaryMuscles",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "secondaryMuscles",
+            "columnName": "secondaryMuscles",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "instructions",
+            "columnName": "instructions",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "category",
+            "columnName": "category",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "images",
+            "columnName": "images",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isCustomExercise",
+            "columnName": "isCustomExercise",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      }
+    ],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, '8e973c578ef7f482bf8261f8db8abc6d')"
+    ]
+  }
+}

--- a/app/src/androidTest/java/org/librefit/ExampleInstrumentedTest.kt
+++ b/app/src/androidTest/java/org/librefit/ExampleInstrumentedTest.kt
@@ -25,6 +25,6 @@ class ExampleInstrumentedTest {
     fun useAppContext() {
         // Context of the app under test.
         val appContext = InstrumentationRegistry.getInstrumentation().targetContext
-        assertEquals(BuildConfig.APPLICATION_ID, appContext.packageName)
+        assertEquals("org.librefit.app", appContext.packageName)
     }
 }

--- a/app/src/androidTest/java/org/librefit/ExampleInstrumentedTest.kt
+++ b/app/src/androidTest/java/org/librefit/ExampleInstrumentedTest.kt
@@ -25,6 +25,6 @@ class ExampleInstrumentedTest {
     fun useAppContext() {
         // Context of the app under test.
         val appContext = InstrumentationRegistry.getInstrumentation().targetContext
-        assertEquals("org.librefit.app", appContext.packageName)
+        assertEquals(BuildConfig.APPLICATION_ID, appContext.packageName)
     }
 }

--- a/app/src/main/java/org/librefit/db/AppDatabase.kt
+++ b/app/src/main/java/org/librefit/db/AppDatabase.kt
@@ -8,10 +8,12 @@
 
 package org.librefit.db
 
+import androidx.room.migration.Migration
 import androidx.room.AutoMigration
 import androidx.room.Database
 import androidx.room.RoomDatabase
 import androidx.room.TypeConverters
+import androidx.sqlite.db.SupportSQLiteDatabase
 import org.librefit.db.converters.ExerciseDCConverter
 import org.librefit.db.converters.LocalDateTimeConverter
 import org.librefit.db.dao.DatasetDao
@@ -25,7 +27,7 @@ import org.librefit.db.entity.Workout
 
 @Database(
     entities = [Workout::class, Exercise::class, Set::class, Measurement::class, ExerciseDC::class],
-    version = 2,
+    version = 3,
     exportSchema = true,
     autoMigrations = [
         AutoMigration(from = 1, to = 2)
@@ -35,6 +37,40 @@ import org.librefit.db.entity.Workout
 abstract class AppDatabase : RoomDatabase() {
     companion object {
         const val NAME = "librefit_database"
+
+        val MIGRATION_2_3 = object : Migration(2, 3) {
+            override fun migrate(database: SupportSQLiteDatabase) {
+                database.execSQL(
+                    """
+                    ALTER TABLE exercises
+                    ADD COLUMN position INTEGER NOT NULL DEFAULT 0
+                    """.trimIndent()
+                )
+                database.execSQL(
+                    """
+                    UPDATE exercises AS current
+                    SET position = (
+                        SELECT COUNT(*) - 1
+                        FROM exercises AS previous
+                        WHERE previous.workoutId = current.workoutId
+                          AND previous.id <= current.id
+                    )
+                    """.trimIndent()
+                )
+                database.execSQL(
+                    """
+                    CREATE INDEX IF NOT EXISTS index_exercises_workoutId_position
+                    ON exercises(workoutId, position)
+                    """.trimIndent()
+                )
+                database.execSQL(
+                    """
+                    CREATE INDEX IF NOT EXISTS index_exercises_idExerciseDC
+                    ON exercises(idExerciseDC)
+                    """.trimIndent()
+                )
+            }
+        }
     }
 
     abstract fun getWorkoutDao(): WorkoutDao

--- a/app/src/main/java/org/librefit/db/AppDatabase.kt
+++ b/app/src/main/java/org/librefit/db/AppDatabase.kt
@@ -8,11 +8,11 @@
 
 package org.librefit.db
 
-import androidx.room.migration.Migration
 import androidx.room.AutoMigration
 import androidx.room.Database
 import androidx.room.RoomDatabase
 import androidx.room.TypeConverters
+import androidx.room.migration.Migration
 import androidx.sqlite.db.SupportSQLiteDatabase
 import org.librefit.db.converters.ExerciseDCConverter
 import org.librefit.db.converters.LocalDateTimeConverter
@@ -39,14 +39,14 @@ abstract class AppDatabase : RoomDatabase() {
         const val NAME = "librefit_database"
 
         val MIGRATION_2_3 = object : Migration(2, 3) {
-            override fun migrate(database: SupportSQLiteDatabase) {
-                database.execSQL(
+            override fun migrate(db: SupportSQLiteDatabase) {
+                db.execSQL(
                     """
                     ALTER TABLE exercises
                     ADD COLUMN position INTEGER NOT NULL DEFAULT 0
                     """.trimIndent()
                 )
-                database.execSQL(
+                db.execSQL(
                     """
                     UPDATE exercises AS current
                     SET position = (
@@ -57,13 +57,13 @@ abstract class AppDatabase : RoomDatabase() {
                     )
                     """.trimIndent()
                 )
-                database.execSQL(
+                db.execSQL(
                     """
                     CREATE INDEX IF NOT EXISTS index_exercises_workoutId_position
                     ON exercises(workoutId, position)
                     """.trimIndent()
                 )
-                database.execSQL(
+                db.execSQL(
                     """
                     CREATE INDEX IF NOT EXISTS index_exercises_idExerciseDC
                     ON exercises(idExerciseDC)

--- a/app/src/main/java/org/librefit/db/dao/WorkoutDao.kt
+++ b/app/src/main/java/org/librefit/db/dao/WorkoutDao.kt
@@ -93,7 +93,7 @@ interface WorkoutDao {
      * This function queries the database to fetch all exercises that belong to the given [Exercise.workoutId]
      */
     @Transaction
-    @Query("SELECT * FROM exercises WHERE workoutId = :workoutId")
+    @Query("SELECT * FROM exercises WHERE workoutId = :workoutId ORDER BY position, id")
     suspend fun getExercisesFromWorkout(workoutId: Long): List<ExerciseWithSets>
 
     /**

--- a/app/src/main/java/org/librefit/db/entity/Exercise.kt
+++ b/app/src/main/java/org/librefit/db/entity/Exercise.kt
@@ -32,6 +32,8 @@ import kotlin.random.Random
  * [org.librefit.ui.screens.workout.WorkoutScreen] and [org.librefit.ui.screens.editWorkout.EditWorkoutScreen]
  * @property restTime The rest time between sets in seconds editable by the user in
  * [org.librefit.ui.screens.workout.WorkoutScreen] and [org.librefit.ui.screens.editWorkout.EditWorkoutScreen]
+ * @property position The explicit position of the exercise in its parent workout. It is used to
+ * keep exercise order stable across reloads and edits.
  * @property workoutId This is a foreign key reference to the [Workout] entity.
  *
  */
@@ -51,7 +53,11 @@ import kotlin.random.Random
             onDelete = ForeignKey.CASCADE // Delete exercise when its respective exerciseDC is deleted
         )
     ],
-    indices = [Index(value = ["workoutId"])]
+    indices = [
+        Index(value = ["workoutId"]),
+        Index(value = ["workoutId", "position"]),
+        Index(value = ["idExerciseDC"])
+    ]
 )
 @Serializable
 data class Exercise(
@@ -60,5 +66,6 @@ data class Exercise(
     val notes: String = "",
     val setMode: SetMode = SetMode.LOAD,
     val restTime: Int = 0,
+    val position: Int = 0,
     val workoutId: Long = 0// Foreign key reference to Workout
 )

--- a/app/src/main/java/org/librefit/db/repository/WorkoutRepository.kt
+++ b/app/src/main/java/org/librefit/db/repository/WorkoutRepository.kt
@@ -35,17 +35,23 @@ import javax.inject.Singleton
 class WorkoutRepository @Inject constructor(
     private val workoutDao: WorkoutDao
 ) {
+    private fun WorkoutWithExercisesAndSets.sortedByExercisePosition(): WorkoutWithExercisesAndSets {
+        return copy(exercisesWithSets = exercisesWithSets.sortedBy { it.exercise.position })
+    }
+
     val completedWorkouts =
         workoutDao.getWorkoutsByStateAndOrderedByCompleted(WorkoutState.COMPLETED)
 
     val routines = workoutDao.getWorkoutsByState(WorkoutState.ROUTINE)
 
     val completedWorkoutsWithExercisesAndSets =
-        workoutDao.getWorkoutsWithExercisesAndSetsByStateAndOrderedByCompleted(WorkoutState.COMPLETED)
+        workoutDao
+            .getWorkoutsWithExercisesAndSetsByStateAndOrderedByCompleted(WorkoutState.COMPLETED)
+            .map { workouts -> workouts.map { it.sortedByExercisePosition() } }
 
-    val runningWorkoutsWithExercisesAndSets = workoutDao.getWorkoutsWithExercisesAndSetsByState(
-        WorkoutState.RUNNING
-    )
+    val runningWorkoutsWithExercisesAndSets =
+        workoutDao.getWorkoutsWithExercisesAndSetsByState(WorkoutState.RUNNING)
+            .map { workouts -> workouts.map { it.sortedByExercisePosition() } }
 
 
 
@@ -77,7 +83,7 @@ class WorkoutRepository @Inject constructor(
         return workoutDao.getWorkoutsWithExercisesAndSetsFromRoutineByState(
             routineId,
             state = WorkoutState.COMPLETED
-        )
+        ).map { it.sortedByExercisePosition() }
     }
 
     /**
@@ -96,7 +102,9 @@ class WorkoutRepository @Inject constructor(
             .map { list ->
                 list.map { w ->
                     w.copy(
-                        exercisesWithSets = w.exercisesWithSets.filter { it.exerciseDC.id == idExerciseDC }
+                        exercisesWithSets = w.exercisesWithSets
+                            .sortedBy { it.exercise.position }
+                            .filter { it.exerciseDC.id == idExerciseDC }
                     )
                 }
             }

--- a/app/src/main/java/org/librefit/di/DatabaseModule.kt
+++ b/app/src/main/java/org/librefit/di/DatabaseModule.kt
@@ -35,6 +35,7 @@ object DatabaseModule {
             AppDatabase::class.java,
             AppDatabase.NAME
         )
+            .addMigrations(AppDatabase.MIGRATION_2_3)
             .build()
     }
 

--- a/app/src/main/java/org/librefit/ui/components/ExerciseCard.kt
+++ b/app/src/main/java/org/librefit/ui/components/ExerciseCard.kt
@@ -117,9 +117,10 @@ import kotlin.math.roundToInt
  * the [org.librefit.ui.screens.infoExercise.InfoExerciseScreen].
  * @param onDelete A lambda function executed when the *Delete* icon is clicked, it should result in
  * the removal of the card.
- * @param isDragging When `true`, the card collapses its editable body to provide clearer reorder feedback.
+ * @param isCollapsed When `true`, the card collapses its editable body to provide clearer reorder feedback.
  * @param showDragHandle Whether a drag handle should be shown in the top-right corner.
  * @param dragHandleModifier Modifier applied to the optional drag handle.
+ * @param onDragHandlePressedChange Reports whether the drag handle is currently pressed.
  * @param updateExerciseNotes A function to update notes based on [UiExercise.id]. For more details, refer to
  * [org.librefit.ui.screens.workout.WorkoutScreenViewModel.updateExerciseNotes] and
  * [org.librefit.ui.screens.editWorkout.EditWorkoutScreenViewModel.updateExerciseNotes].
@@ -169,9 +170,10 @@ fun SharedTransitionScope.ExerciseCard(
     addSet: (Long) -> Unit,
     onDetail: (Long, String) -> Unit,
     onDelete: (Long) -> Unit,
-    isDragging: Boolean = false,
+    isCollapsed: Boolean = false,
     showDragHandle: Boolean = false,
     dragHandleModifier: Modifier = Modifier,
+    onDragHandlePressedChange: (Boolean) -> Unit = {},
     deleteSet: (Long) -> Unit,
     updateExerciseNotes: (String, Long) -> Unit,
     updateExerciseRestTime: (Int, Long) -> Unit,
@@ -186,7 +188,10 @@ fun SharedTransitionScope.ExerciseCard(
 ) {
     val dragHandleInteractionSource = remember { MutableInteractionSource() }
     val isDragHandlePressed by dragHandleInteractionSource.collectIsPressedAsState()
-    val isCollapsed = isDragging || isDragHandlePressed
+
+    LaunchedEffect(isDragHandlePressed) {
+        onDragHandlePressedChange(isDragHandlePressed)
+    }
 
     ElevatedCard(
         modifier = modifier,

--- a/app/src/main/java/org/librefit/ui/components/ExerciseCard.kt
+++ b/app/src/main/java/org/librefit/ui/components/ExerciseCard.kt
@@ -18,6 +18,8 @@ import androidx.compose.animation.animateContentSize
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.focusable
+import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.interaction.collectIsPressedAsState
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
@@ -182,6 +184,10 @@ fun SharedTransitionScope.ExerciseCard(
     updateIdSetWithRunningStopwatch: (Long?) -> Unit = {},
     applyPreviousSetPerformance: (Long) -> Unit = {}
 ) {
+    val dragHandleInteractionSource = remember { MutableInteractionSource() }
+    val isDragHandlePressed by dragHandleInteractionSource.collectIsPressedAsState()
+    val isCollapsed = isDragging || isDragHandlePressed
+
     ElevatedCard(
         modifier = modifier,
         shape = MaterialTheme.shapes.extraLarge
@@ -239,6 +245,7 @@ fun SharedTransitionScope.ExerciseCard(
                     if (showDragHandle) {
                         IconButton(
                             modifier = dragHandleModifier,
+                            interactionSource = dragHandleInteractionSource,
                             onClick = {}
                         ) {
                             Icon(
@@ -256,7 +263,7 @@ fun SharedTransitionScope.ExerciseCard(
                 }
             }
 
-            AnimatedVisibility(visible = !isDragging) {
+            AnimatedVisibility(visible = !isCollapsed) {
                 Column(
                     modifier = Modifier.fillMaxWidth(),
                     horizontalAlignment = Alignment.CenterHorizontally,

--- a/app/src/main/java/org/librefit/ui/components/ExerciseCard.kt
+++ b/app/src/main/java/org/librefit/ui/components/ExerciseCard.kt
@@ -8,6 +8,7 @@
 
 package org.librefit.ui.components
 
+import androidx.compose.animation.AnimatedContent
 import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.AnimatedVisibilityScope
 import androidx.compose.animation.ExperimentalSharedTransitionApi
@@ -18,8 +19,6 @@ import androidx.compose.animation.animateContentSize
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.focusable
-import androidx.compose.foundation.interaction.MutableInteractionSource
-import androidx.compose.foundation.interaction.collectIsPressedAsState
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
@@ -35,7 +34,9 @@ import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.Checkbox
+import androidx.compose.material3.DropdownMenuGroup
 import androidx.compose.material3.DropdownMenuItem
+import androidx.compose.material3.DropdownMenuPopup
 import androidx.compose.material3.ElevatedCard
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.ExperimentalMaterial3ExpressiveApi
@@ -48,6 +49,7 @@ import androidx.compose.material3.IconButton
 import androidx.compose.material3.IconButtonDefaults
 import androidx.compose.material3.IconToggleButton
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.MenuDefaults
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.OutlinedTextFieldDefaults
 import androidx.compose.material3.Slider
@@ -117,10 +119,9 @@ import kotlin.math.roundToInt
  * the [org.librefit.ui.screens.infoExercise.InfoExerciseScreen].
  * @param onDelete A lambda function executed when the *Delete* icon is clicked, it should result in
  * the removal of the card.
- * @param isCollapsed When `true`, the card collapses its editable body to provide clearer reorder feedback.
- * @param showDragHandle Whether a drag handle should be shown in the top-right corner.
+ * @param isCollapsed When `true`, the card collapses its editable body to provide clearer reorder feedback. So it's true only when reordering.
  * @param dragHandleModifier Modifier applied to the optional drag handle.
- * @param onDragHandlePressedChange Reports whether the drag handle is currently pressed.
+ * @param onReorderRequest A lambda triggered when the `reorder` option from dropdown menu is pressed.
  * @param updateExerciseNotes A function to update notes based on [UiExercise.id]. For more details, refer to
  * [org.librefit.ui.screens.workout.WorkoutScreenViewModel.updateExerciseNotes] and
  * [org.librefit.ui.screens.editWorkout.EditWorkoutScreenViewModel.updateExerciseNotes].
@@ -171,9 +172,8 @@ fun SharedTransitionScope.ExerciseCard(
     onDetail: (Long, String) -> Unit,
     onDelete: (Long) -> Unit,
     isCollapsed: Boolean = false,
-    showDragHandle: Boolean = false,
     dragHandleModifier: Modifier = Modifier,
-    onDragHandlePressedChange: (Boolean) -> Unit = {},
+    onReorderRequest: () -> Unit,
     deleteSet: (Long) -> Unit,
     updateExerciseNotes: (String, Long) -> Unit,
     updateExerciseRestTime: (Int, Long) -> Unit,
@@ -186,13 +186,7 @@ fun SharedTransitionScope.ExerciseCard(
     updateIdSetWithRunningStopwatch: (Long?) -> Unit = {},
     applyPreviousSetPerformance: (Long) -> Unit = {}
 ) {
-    val dragHandleInteractionSource = remember { MutableInteractionSource() }
-    val isDragHandlePressed by dragHandleInteractionSource.collectIsPressedAsState()
-
-    LaunchedEffect(isDragHandlePressed) {
-        onDragHandlePressedChange(isDragHandlePressed)
-    }
-
+    var showMenu by rememberSaveable { mutableStateOf(false) }
     ElevatedCard(
         modifier = modifier,
         shape = MaterialTheme.shapes.extraLarge
@@ -213,7 +207,7 @@ fun SharedTransitionScope.ExerciseCard(
                     modifier = Modifier
                         .weight(1f)
                         .clip(MaterialTheme.shapes.medium)
-                        .clickable {
+                        .clickable(enabled = !isCollapsed) {
                             onDetail(exerciseWithSets.exercise.id, exerciseWithSets.exerciseDC.id)
                         },
                     verticalAlignment = Alignment.CenterVertically
@@ -246,24 +240,66 @@ fun SharedTransitionScope.ExerciseCard(
                         modifier = Modifier.weight(1f)
                     )
                 }
-                Row(verticalAlignment = Alignment.CenterVertically) {
-                    if (showDragHandle) {
-                        IconButton(
-                            modifier = dragHandleModifier,
-                            interactionSource = dragHandleInteractionSource,
-                            onClick = {}
-                        ) {
-                            Icon(
-                                painter = painterResource(R.drawable.ic_drag_handle),
-                                contentDescription = stringResource(R.string.reorder)
-                            )
+                Column {
+                    AnimatedContent(
+                        targetState = isCollapsed,
+                        label = "DragHandleTransition",
+                    ) { isReordering ->
+                        if (isReordering) {
+                            IconButton(
+                                modifier = dragHandleModifier,
+                                onClick = {}
+                            ) {
+                                Icon(
+                                    painter = painterResource(R.drawable.ic_drag_handle),
+                                    contentDescription = stringResource(R.string.reorder)
+                                )
+                            }
+                        } else {
+                            IconButton(
+                                onClick = { showMenu = true }
+                            ) {
+                                Icon(
+                                    painter = painterResource(R.drawable.ic_more_options),
+                                    contentDescription = stringResource(R.string.more_options)
+                                )
+                            }
+                            DropdownMenuPopup(
+                                expanded = showMenu,
+                                onDismissRequest = { showMenu = false }) {
+                                DropdownMenuGroup(
+                                    shapes = MenuDefaults.groupShape(0, 1) // Top-level group shape
+                                ) {
+                                    // MenuDefaults.Label { Text("Header") }
+                                    DropdownMenuItem(
+                                        text = { Text(stringResource(R.string.reorder)) },
+                                        leadingIcon = {
+                                            Icon(
+                                                painterResource(R.drawable.ic_reorder),
+                                                stringResource(R.string.reorder)
+                                            )
+                                        },
+                                        onClick = {
+                                            onReorderRequest()
+                                            showMenu = false
+                                        }
+                                    )
+                                    DropdownMenuItem(
+                                        text = { Text(stringResource(R.string.delete)) },
+                                        leadingIcon = {
+                                            Icon(
+                                                painterResource(R.drawable.ic_delete),
+                                                stringResource(R.string.delete)
+                                            )
+                                        },
+                                        onClick = {
+                                            onDelete(exerciseWithSets.exercise.id)
+                                            showMenu = false
+                                        }
+                                    )
+                                }
+                            }
                         }
-                    }
-                    IconButton(onClick = { onDelete(exerciseWithSets.exercise.id) }) {
-                        Icon(
-                            painter = painterResource(R.drawable.ic_delete),
-                            contentDescription = stringResource(R.string.delete)
-                        )
                     }
                 }
             }
@@ -877,7 +913,8 @@ private fun ExerciseCardPreview() {
                                 }.toImmutableList()
                             )
                         }
-                    }
+                    },
+                    onReorderRequest = {}
                 )
             }
         }

--- a/app/src/main/java/org/librefit/ui/components/ExerciseCard.kt
+++ b/app/src/main/java/org/librefit/ui/components/ExerciseCard.kt
@@ -115,6 +115,8 @@ import kotlin.math.roundToInt
  * the [org.librefit.ui.screens.infoExercise.InfoExerciseScreen].
  * @param onDelete A lambda function executed when the *Delete* icon is clicked, it should result in
  * the removal of the card.
+ * @param showDragHandle Whether a drag handle should be shown in the top-right corner.
+ * @param dragHandleModifier Modifier applied to the optional drag handle.
  * @param updateExerciseNotes A function to update notes based on [UiExercise.id]. For more details, refer to
  * [org.librefit.ui.screens.workout.WorkoutScreenViewModel.updateExerciseNotes] and
  * [org.librefit.ui.screens.editWorkout.EditWorkoutScreenViewModel.updateExerciseNotes].
@@ -164,6 +166,8 @@ fun SharedTransitionScope.ExerciseCard(
     addSet: (Long) -> Unit,
     onDetail: (Long, String) -> Unit,
     onDelete: (Long) -> Unit,
+    showDragHandle: Boolean = false,
+    dragHandleModifier: Modifier = Modifier,
     deleteSet: (Long) -> Unit,
     updateExerciseNotes: (String, Long) -> Unit,
     updateExerciseRestTime: (Int, Long) -> Unit,
@@ -229,11 +233,24 @@ fun SharedTransitionScope.ExerciseCard(
                         modifier = Modifier.weight(1f)
                     )
                 }
-                IconButton(onClick = { onDelete(exerciseWithSets.exercise.id) }) {
-                    Icon(
-                        painter = painterResource(R.drawable.ic_delete),
-                        contentDescription = stringResource(R.string.delete)
-                    )
+                Row(verticalAlignment = Alignment.CenterVertically) {
+                    if (showDragHandle) {
+                        IconButton(
+                            modifier = dragHandleModifier,
+                            onClick = {}
+                        ) {
+                            Icon(
+                                painter = painterResource(R.drawable.ic_drag_handle),
+                                contentDescription = stringResource(R.string.reorder)
+                            )
+                        }
+                    }
+                    IconButton(onClick = { onDelete(exerciseWithSets.exercise.id) }) {
+                        Icon(
+                            painter = painterResource(R.drawable.ic_delete),
+                            contentDescription = stringResource(R.string.delete)
+                        )
+                    }
                 }
             }
 

--- a/app/src/main/java/org/librefit/ui/components/ExerciseCard.kt
+++ b/app/src/main/java/org/librefit/ui/components/ExerciseCard.kt
@@ -71,6 +71,7 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.draw.shadow
 import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.graphics.Color
@@ -119,9 +120,10 @@ import kotlin.math.roundToInt
  * the [org.librefit.ui.screens.infoExercise.InfoExerciseScreen].
  * @param onDelete A lambda function executed when the *Delete* icon is clicked, it should result in
  * the removal of the card.
- * @param isCollapsed When `true`, the card collapses its editable body to provide clearer reorder feedback. So it's true only when reordering.
+ * @param isCollapsed When `true`, the card collapses its editable body to provide clearer reorder feedback. So it's true only when reordering one of exercises in the list.
  * @param dragHandleModifier Modifier applied to the optional drag handle.
  * @param onReorderRequest A lambda triggered when the `reorder` option from dropdown menu is pressed.
+ * @param isDragging when `true`, it applies a shadow to further emphasize with a shadow that the card is dragged.
  * @param updateExerciseNotes A function to update notes based on [UiExercise.id]. For more details, refer to
  * [org.librefit.ui.screens.workout.WorkoutScreenViewModel.updateExerciseNotes] and
  * [org.librefit.ui.screens.editWorkout.EditWorkoutScreenViewModel.updateExerciseNotes].
@@ -173,6 +175,7 @@ fun SharedTransitionScope.ExerciseCard(
     onDelete: (Long) -> Unit,
     isCollapsed: Boolean = false,
     dragHandleModifier: Modifier = Modifier,
+    isDragging: Boolean,
     onReorderRequest: () -> Unit,
     deleteSet: (Long) -> Unit,
     updateExerciseNotes: (String, Long) -> Unit,
@@ -187,9 +190,15 @@ fun SharedTransitionScope.ExerciseCard(
     applyPreviousSetPerformance: (Long) -> Unit = {}
 ) {
     var showMenu by rememberSaveable { mutableStateOf(false) }
+    val shape = MaterialTheme.shapes.extraLarge
     ElevatedCard(
-        modifier = modifier,
-        shape = MaterialTheme.shapes.extraLarge
+        modifier = modifier.then(
+            if (isDragging) Modifier.shadow(
+                10.dp,
+                shape = shape
+            ) else Modifier
+        ),
+        shape = shape
     ) {
         Column(
             modifier = Modifier
@@ -856,6 +865,7 @@ private fun ExerciseCardPreview() {
                     idSetWithRunningStopwatch = currentIdSetWithRunningSet.value,
                     updateIdSetWithRunningStopwatch = { currentIdSetWithRunningSet.value = it },
                     workout = true,
+                    isDragging = false,
                     updateExerciseNotes = { notes, _ ->
                         e.value = e.value.copy(exercise = e.value.exercise.copy(notes = notes))
                     },
@@ -914,7 +924,7 @@ private fun ExerciseCardPreview() {
                             )
                         }
                     },
-                    onReorderRequest = {}
+                    onReorderRequest = {},
                 )
             }
         }

--- a/app/src/main/java/org/librefit/ui/components/ExerciseCard.kt
+++ b/app/src/main/java/org/librefit/ui/components/ExerciseCard.kt
@@ -115,6 +115,7 @@ import kotlin.math.roundToInt
  * the [org.librefit.ui.screens.infoExercise.InfoExerciseScreen].
  * @param onDelete A lambda function executed when the *Delete* icon is clicked, it should result in
  * the removal of the card.
+ * @param isDragging When `true`, the card collapses its editable body to provide clearer reorder feedback.
  * @param showDragHandle Whether a drag handle should be shown in the top-right corner.
  * @param dragHandleModifier Modifier applied to the optional drag handle.
  * @param updateExerciseNotes A function to update notes based on [UiExercise.id]. For more details, refer to
@@ -166,6 +167,7 @@ fun SharedTransitionScope.ExerciseCard(
     addSet: (Long) -> Unit,
     onDetail: (Long, String) -> Unit,
     onDelete: (Long) -> Unit,
+    isDragging: Boolean = false,
     showDragHandle: Boolean = false,
     dragHandleModifier: Modifier = Modifier,
     deleteSet: (Long) -> Unit,
@@ -254,247 +256,254 @@ fun SharedTransitionScope.ExerciseCard(
                 }
             }
 
-            OutlinedTextField(
-                shape = MaterialTheme.shapes.large,
-                modifier = Modifier.fillMaxWidth(),
-                label = { Text(text = stringResource(id = R.string.notes)) },
-                value = exerciseWithSets.exercise.notes,
-                onValueChange = { updateExerciseNotes(it, exerciseWithSets.exercise.id) }
-            )
-
-            //Rest timer slider
-            Column {
-                var showSlider by rememberSaveable { mutableStateOf(false) }
-                var restTime by remember { mutableIntStateOf(exerciseWithSets.exercise.restTime) }
-                val haptic = LocalHapticFeedback.current
-                Row(
+            AnimatedVisibility(visible = !isDragging) {
+                Column(
                     modifier = Modifier.fillMaxWidth(),
-                    horizontalArrangement = Arrangement.SpaceAround,
-                    verticalAlignment = Alignment.CenterVertically
-                ) {
-                    Row(
-                        horizontalArrangement = Arrangement.Center,
-                        verticalAlignment = Alignment.CenterVertically
-                    ) {
-                        IconButton(
-                            // Read more at InfoModalBottomSheet
-                            onClick = { showInfo(InfoMode.REST_TIMER) }
-                        ) {
-                            Icon(
-                                painter = painterResource(R.drawable.ic_info),
-                                contentDescription = stringResource(R.string.info)
-                            )
-                        }
-                        Text(
-                            stringResource(R.string.rest_time) + ": " + restTime
-                                    + " " + stringResource(R.string.seconds).replaceFirstChar { it.lowercase() })
-                    }
-                    IconToggleButton(
-                        checked = showSlider,
-                        onCheckedChange = {
-                            showSlider = it
-                            haptic.performHapticFeedback(if (it) HapticFeedbackType.ToggleOn else HapticFeedbackType.ToggleOff)
-                        }
-                    ) {
-                        Icon(
-                            painter = painterResource(if (showSlider) R.drawable.ic_check else R.drawable.ic_edit),
-                            contentDescription = stringResource(if (showSlider) R.string.save else R.string.edit)
-                        )
-                    }
-                }
-                AnimatedVisibility(visible = showSlider) {
-                    Slider(
-                        value = restTime.toFloat(),
-                        onValueChange = {
-                            // By dividing first and then multiplying by 5, it rounds to the closest number multiple of 5
-                            restTime = (it / 5).roundToInt() * 5
-                            haptic.performHapticFeedback(HapticFeedbackType.SegmentFrequentTick)
-                        },
-                        onValueChangeFinished = {
-                            updateExerciseRestTime(
-                                restTime,
-                                exerciseWithSets.exercise.id
-                            )
-                        },
-                        valueRange = 0f..300f,
-                        // 19 steps means values multiple of 5
-                        steps = 19
-                    )
-                }
-            }
-
-            HorizontalDivider()
-
-            // Set mode selection
-            Row(
-                modifier = Modifier.fillMaxWidth(),
-                horizontalArrangement = Arrangement.SpaceAround,
-                verticalAlignment = Alignment.CenterVertically
-            ) {
-                Row(
-                    modifier = Modifier.weight(0.5f),
-                    verticalAlignment = Alignment.CenterVertically,
-                    horizontalArrangement = Arrangement.Center
-                ) {
-                    IconButton(
-                        // Refer to InfoModalBottomSheet to know the reason behind this value.
-                        // Do NOT change it.
-                        onClick = { showInfo(InfoMode.TYPE_OF_SET) }
-                    ) {
-                        Icon(
-                            painter = painterResource(R.drawable.ic_info),
-                            contentDescription = stringResource(R.string.info) + ":"
-                        )
-                    }
-                    Text(stringResource(R.string.type_of_set))
-                }
-
-
-                var expanded by remember { mutableStateOf(false) }
-
-                val focusRequester = remember { FocusRequester() }
-
-                // Type of set selector
-                ExposedDropdownMenuBox(
-                    expanded = expanded,
-                    onExpandedChange = { expanded = it },
-                    modifier = Modifier
-                        .padding(start = 10.dp, end = 10.dp)
-                        .weight(0.5f)
-                        .clickable {
-                            expanded = !expanded
-                            focusRequester.requestFocus()
-                        }
-                        .focusRequester(focusRequester)
-                        .focusable()
+                    horizontalAlignment = Alignment.CenterHorizontally,
+                    verticalArrangement = Arrangement.spacedBy(10.dp)
                 ) {
                     OutlinedTextField(
                         shape = MaterialTheme.shapes.large,
-                        readOnly = true,
-                        value = stringResource(Formatter.setModeToStringId(exerciseWithSets.exercise.setMode)),
-                        onValueChange = {},
-                        singleLine = true,
-                        trailingIcon = {
-                            ExposedDropdownMenuDefaults.TrailingIcon(expanded = expanded)
-                        },
-                        modifier = Modifier.menuAnchor(ExposedDropdownMenuAnchorType.PrimaryNotEditable),
-                        colors = ExposedDropdownMenuDefaults.outlinedTextFieldColors()
+                        modifier = Modifier.fillMaxWidth(),
+                        label = { Text(text = stringResource(id = R.string.notes)) },
+                        value = exerciseWithSets.exercise.notes,
+                        onValueChange = { updateExerciseNotes(it, exerciseWithSets.exercise.id) }
                     )
-                    ExposedDropdownMenu(
-                        expanded = expanded,
-                        onDismissRequest = { expanded = false }
-                    ) {
-                        SetMode.entries.forEachIndexed { _, mode ->
-                            DropdownMenuItem(
-                                onClick = {
-                                    updateExerciseSetMode(mode, exerciseWithSets.exercise.id)
-                                    expanded = false
+
+                    //Rest timer slider
+                    Column {
+                        var showSlider by rememberSaveable { mutableStateOf(false) }
+                        var restTime by remember { mutableIntStateOf(exerciseWithSets.exercise.restTime) }
+                        val haptic = LocalHapticFeedback.current
+                        Row(
+                            modifier = Modifier.fillMaxWidth(),
+                            horizontalArrangement = Arrangement.SpaceAround,
+                            verticalAlignment = Alignment.CenterVertically
+                        ) {
+                            Row(
+                                horizontalArrangement = Arrangement.Center,
+                                verticalAlignment = Alignment.CenterVertically
+                            ) {
+                                IconButton(
+                                    // Read more at InfoModalBottomSheet
+                                    onClick = { showInfo(InfoMode.REST_TIMER) }
+                                ) {
+                                    Icon(
+                                        painter = painterResource(R.drawable.ic_info),
+                                        contentDescription = stringResource(R.string.info)
+                                    )
+                                }
+                                Text(
+                                    stringResource(R.string.rest_time) + ": " + restTime
+                                            + " " + stringResource(R.string.seconds).replaceFirstChar { it.lowercase() })
+                            }
+                            IconToggleButton(
+                                checked = showSlider,
+                                onCheckedChange = {
+                                    showSlider = it
+                                    haptic.performHapticFeedback(if (it) HapticFeedbackType.ToggleOn else HapticFeedbackType.ToggleOff)
+                                }
+                            ) {
+                                Icon(
+                                    painter = painterResource(if (showSlider) R.drawable.ic_check else R.drawable.ic_edit),
+                                    contentDescription = stringResource(if (showSlider) R.string.save else R.string.edit)
+                                )
+                            }
+                        }
+                        AnimatedVisibility(visible = showSlider) {
+                            Slider(
+                                value = restTime.toFloat(),
+                                onValueChange = {
+                                    // By dividing first and then multiplying by 5, it rounds to the closest number multiple of 5
+                                    restTime = (it / 5).roundToInt() * 5
+                                    haptic.performHapticFeedback(HapticFeedbackType.SegmentFrequentTick)
                                 },
-                                text = {
-                                    Text(
-                                        text = stringResource(Formatter.setModeToStringId(mode))
+                                onValueChangeFinished = {
+                                    updateExerciseRestTime(
+                                        restTime,
+                                        exerciseWithSets.exercise.id
                                     )
                                 },
-                                trailingIcon = if (exerciseWithSets.exercise.setMode == mode) {
-                                    {
-                                        Icon(
-                                            painter = painterResource(R.drawable.ic_check),
-                                            contentDescription = stringResource(R.string.checkbox)
-                                        )
-                                    }
-                                } else null,
-                                modifier = Modifier.background(
-                                    if (exerciseWithSets.exercise.setMode == mode) MaterialTheme.colorScheme.inversePrimary.copy(
-                                        0.3f
-                                    ) else Color.Unspecified
-                                )
+                                valueRange = 0f..300f,
+                                // 19 steps means values multiple of 5
+                                steps = 19
                             )
                         }
                     }
-                }
-            }
 
-            ElevatedCard(
-                shape = MaterialTheme.shapes.extraLarge,
-                colors = CardDefaults.elevatedCardColors(
-                    containerColor = MaterialTheme.colorScheme.surfaceContainerHighest
-                )
-            ) {
-                //Headline set
-                Row(
-                    modifier = Modifier
-                        .padding(10.dp)
-                        .fillMaxWidth(),
-                    verticalAlignment = Alignment.CenterVertically,
-                    horizontalArrangement = Arrangement.SpaceBetween
-                ) {
-                    Spacer(Modifier)
-                    if (previousPerformances != null) {
-                        Text(
-                            text = stringResource(R.string.previous),
-                            color = MaterialTheme.colorScheme.secondary
-                        )
-                    }
-                    if (exerciseWithSets.exercise.setMode == SetMode.DURATION) {
-                        Text(
-                            text = stringResource(R.string.time),
-                            color = MaterialTheme.colorScheme.secondary
-                        )
-                    } else {
-                        if (exerciseWithSets.exercise.setMode == SetMode.LOAD ||
-                            exerciseWithSets.exercise.setMode == SetMode.BODYWEIGHT_WITH_LOAD
+                    HorizontalDivider()
+
+                    // Set mode selection
+                    Row(
+                        modifier = Modifier.fillMaxWidth(),
+                        horizontalArrangement = Arrangement.SpaceAround,
+                        verticalAlignment = Alignment.CenterVertically
+                    ) {
+                        Row(
+                            modifier = Modifier.weight(0.5f),
+                            verticalAlignment = Alignment.CenterVertically,
+                            horizontalArrangement = Arrangement.Center
                         ) {
-                            Text(
-                                text = stringResource(R.string.load) + " (" + stringResource(R.string.kg) + ")",
-                                color = MaterialTheme.colorScheme.secondary
-                            )
+                            IconButton(
+                                // Refer to InfoModalBottomSheet to know the reason behind this value.
+                                // Do NOT change it.
+                                onClick = { showInfo(InfoMode.TYPE_OF_SET) }
+                            ) {
+                                Icon(
+                                    painter = painterResource(R.drawable.ic_info),
+                                    contentDescription = stringResource(R.string.info) + ":"
+                                )
+                            }
+                            Text(stringResource(R.string.type_of_set))
                         }
-                        Text(
-                            text = stringResource(id = R.string.reps),
-                            color = MaterialTheme.colorScheme.secondary
-                        )
-                    }
-                    if (workout) {
-                        Icon(
-                            painter = painterResource(R.drawable.ic_check),
-                            contentDescription = stringResource(R.string.done)
-                        )
-                    }
-                }
 
-                //Sets
-                Column(modifier = Modifier.animateContentSize()) {
-                    exerciseWithSets.sets.forEachIndexed { i, set ->
-                        key(set.id) {
-                            Set(
-                                i = i,
-                                set = set,
-                                previousSet = previousPerformances?.getOrNull(i),
-                                lastIndex = exerciseWithSets.sets.lastIndex,
-                                setMode = exerciseWithSets.exercise.setMode,
-                                isStopwatchRunning = idSetWithRunningStopwatch == null,
-                                isThisSetStopwatchRunning = idSetWithRunningStopwatch == set.id,
-                                workout = workout,
-                                deleteSet = deleteSet,
-                                updateIdSetWithRunningStopwatch = updateIdSetWithRunningStopwatch,
-                                updateSetTime = updateSetTime,
-                                updateSetReps = updateSetReps,
-                                updateSetLoad = updateSetLoad,
-                                updateSetCompleted = updateSetCompleted,
-                                applyPreviousSet = applyPreviousSetPerformance
+                        var expanded by remember { mutableStateOf(false) }
+
+                        val focusRequester = remember { FocusRequester() }
+
+                        // Type of set selector
+                        ExposedDropdownMenuBox(
+                            expanded = expanded,
+                            onExpandedChange = { expanded = it },
+                            modifier = Modifier
+                                .padding(start = 10.dp, end = 10.dp)
+                                .weight(0.5f)
+                                .clickable {
+                                    expanded = !expanded
+                                    focusRequester.requestFocus()
+                                }
+                                .focusRequester(focusRequester)
+                                .focusable()
+                        ) {
+                            OutlinedTextField(
+                                shape = MaterialTheme.shapes.large,
+                                readOnly = true,
+                                value = stringResource(Formatter.setModeToStringId(exerciseWithSets.exercise.setMode)),
+                                onValueChange = {},
+                                singleLine = true,
+                                trailingIcon = {
+                                    ExposedDropdownMenuDefaults.TrailingIcon(expanded = expanded)
+                                },
+                                modifier = Modifier.menuAnchor(ExposedDropdownMenuAnchorType.PrimaryNotEditable),
+                                colors = ExposedDropdownMenuDefaults.outlinedTextFieldColors()
                             )
+                            ExposedDropdownMenu(
+                                expanded = expanded,
+                                onDismissRequest = { expanded = false }
+                            ) {
+                                SetMode.entries.forEachIndexed { _, mode ->
+                                    DropdownMenuItem(
+                                        onClick = {
+                                            updateExerciseSetMode(mode, exerciseWithSets.exercise.id)
+                                            expanded = false
+                                        },
+                                        text = {
+                                            Text(
+                                                text = stringResource(Formatter.setModeToStringId(mode))
+                                            )
+                                        },
+                                        trailingIcon = if (exerciseWithSets.exercise.setMode == mode) {
+                                            {
+                                                Icon(
+                                                    painter = painterResource(R.drawable.ic_check),
+                                                    contentDescription = stringResource(R.string.checkbox)
+                                                )
+                                            }
+                                        } else null,
+                                        modifier = Modifier.background(
+                                            if (exerciseWithSets.exercise.setMode == mode) MaterialTheme.colorScheme.inversePrimary.copy(
+                                                0.3f
+                                            ) else Color.Unspecified
+                                        )
+                                    )
+                                }
+                            }
                         }
                     }
+
+                    ElevatedCard(
+                        shape = MaterialTheme.shapes.extraLarge,
+                        colors = CardDefaults.elevatedCardColors(
+                            containerColor = MaterialTheme.colorScheme.surfaceContainerHighest
+                        )
+                    ) {
+                        //Headline set
+                        Row(
+                            modifier = Modifier
+                                .padding(10.dp)
+                                .fillMaxWidth(),
+                            verticalAlignment = Alignment.CenterVertically,
+                            horizontalArrangement = Arrangement.SpaceBetween
+                        ) {
+                            Spacer(Modifier)
+                            if (previousPerformances != null) {
+                                Text(
+                                    text = stringResource(R.string.previous),
+                                    color = MaterialTheme.colorScheme.secondary
+                                )
+                            }
+                            if (exerciseWithSets.exercise.setMode == SetMode.DURATION) {
+                                Text(
+                                    text = stringResource(R.string.time),
+                                    color = MaterialTheme.colorScheme.secondary
+                                )
+                            } else {
+                                if (exerciseWithSets.exercise.setMode == SetMode.LOAD ||
+                                    exerciseWithSets.exercise.setMode == SetMode.BODYWEIGHT_WITH_LOAD
+                                ) {
+                                    Text(
+                                        text = stringResource(R.string.load) + " (" + stringResource(R.string.kg) + ")",
+                                        color = MaterialTheme.colorScheme.secondary
+                                    )
+                                }
+                                Text(
+                                    text = stringResource(id = R.string.reps),
+                                    color = MaterialTheme.colorScheme.secondary
+                                )
+                            }
+                            if (workout) {
+                                Icon(
+                                    painter = painterResource(R.drawable.ic_check),
+                                    contentDescription = stringResource(R.string.done)
+                                )
+                            }
+                        }
+
+                        //Sets
+                        Column(modifier = Modifier.animateContentSize()) {
+                            exerciseWithSets.sets.forEachIndexed { i, set ->
+                                key(set.id) {
+                                    Set(
+                                        i = i,
+                                        set = set,
+                                        previousSet = previousPerformances?.getOrNull(i),
+                                        lastIndex = exerciseWithSets.sets.lastIndex,
+                                        setMode = exerciseWithSets.exercise.setMode,
+                                        isStopwatchRunning = idSetWithRunningStopwatch == null,
+                                        isThisSetStopwatchRunning = idSetWithRunningStopwatch == set.id,
+                                        workout = workout,
+                                        deleteSet = deleteSet,
+                                        updateIdSetWithRunningStopwatch = updateIdSetWithRunningStopwatch,
+                                        updateSetTime = updateSetTime,
+                                        updateSetReps = updateSetReps,
+                                        updateSetLoad = updateSetLoad,
+                                        updateSetCompleted = updateSetCompleted,
+                                        applyPreviousSet = applyPreviousSetPerformance
+                                    )
+                                }
+                            }
+                        }
+                    }
+
+                    //Add set button
+                    LibreFitButton(
+                        text = stringResource(id = R.string.add_set),
+                        icon = painterResource(R.drawable.ic_add_circle),
+                        onClick = { addSet(exerciseWithSets.exercise.id) },
+                        elevated = false
+                    )
                 }
             }
-
-            //Add set button
-            LibreFitButton(
-                text = stringResource(id = R.string.add_set),
-                icon = painterResource(R.drawable.ic_add_circle),
-                onClick = { addSet(exerciseWithSets.exercise.id) },
-                elevated = false
-            )
         }
     }
 }

--- a/app/src/main/java/org/librefit/ui/models/ExerciseOrder.kt
+++ b/app/src/main/java/org/librefit/ui/models/ExerciseOrder.kt
@@ -1,0 +1,25 @@
+/*
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ * Copyright (c) 2025-2026. The LibreFit Contributors
+ *
+ * LibreFit is subject to additional terms covering author attribution and trademark usage;
+ * see the ADDITIONAL_TERMS.md and TRADEMARK_POLICY.md files in the project root.
+ */
+
+package org.librefit.ui.models
+
+fun List<UiExerciseWithSets>.withNormalizedExercisePositions(): List<UiExerciseWithSets> {
+    return mapIndexed { index, exerciseWithSets ->
+        exerciseWithSets.copy(exercise = exerciseWithSets.exercise.copy(position = index))
+    }
+}
+
+fun List<UiExerciseWithSets>.moveExercise(fromIndex: Int, toIndex: Int): List<UiExerciseWithSets> {
+    if (fromIndex == toIndex || fromIndex !in indices || toIndex !in indices) return this
+
+    return toMutableList()
+        .apply {
+            add(toIndex, removeAt(fromIndex))
+        }
+        .withNormalizedExercisePositions()
+}

--- a/app/src/main/java/org/librefit/ui/models/UiExercise.kt
+++ b/app/src/main/java/org/librefit/ui/models/UiExercise.kt
@@ -27,5 +27,6 @@ data class UiExercise(
     val notes: String = "",
     val setMode: SetMode = SetMode.LOAD,
     val restTime: Int = 0,
+    val position: Int = 0,
     val workoutId: Long = 0
 )

--- a/app/src/main/java/org/librefit/ui/models/mappers/UiExerciseMapper.kt
+++ b/app/src/main/java/org/librefit/ui/models/mappers/UiExerciseMapper.kt
@@ -18,6 +18,7 @@ fun Exercise.toUi(): UiExercise {
         notes = this.notes,
         setMode = this.setMode,
         restTime = this.restTime,
+        position = this.position,
         workoutId = this.workoutId
     )
 }
@@ -29,6 +30,7 @@ fun UiExercise.toEntity(): Exercise {
         notes = this.notes,
         setMode = this.setMode,
         restTime = this.restTime,
+        position = this.position,
         workoutId = this.workoutId
     )
 }

--- a/app/src/main/java/org/librefit/ui/models/mappers/UiWorkoutWithExercisesAndSetsMapper.kt
+++ b/app/src/main/java/org/librefit/ui/models/mappers/UiWorkoutWithExercisesAndSetsMapper.kt
@@ -15,7 +15,10 @@ import org.librefit.ui.models.UiWorkoutWithExercisesAndSets
 fun WorkoutWithExercisesAndSets.toUi(): UiWorkoutWithExercisesAndSets {
     return UiWorkoutWithExercisesAndSets(
         workout = workout.toUi(),
-        exercisesWithSets = exercisesWithSets.map { it.toUi() }.toImmutableList()
+        exercisesWithSets = exercisesWithSets
+            .sortedBy { it.exercise.position }
+            .map { it.toUi() }
+            .toImmutableList()
     )
 }
 

--- a/app/src/main/java/org/librefit/ui/screens/editWorkout/EditWorkoutScreen.kt
+++ b/app/src/main/java/org/librefit/ui/screens/editWorkout/EditWorkoutScreen.kt
@@ -195,6 +195,10 @@ private fun SharedTransitionScope.EditWorkoutScreenContent(
 
     val lazyListState = rememberLazyListState()
     val hapticFeedback = LocalHapticFeedback.current
+    // We track the exercise id so a release event from one card can't clear the collapse state while another card is still being pressed or dragged.
+    var pressedExerciseId by remember { mutableStateOf<Long?>(null) }
+    var draggingExerciseId by remember { mutableStateOf<Long?>(null) }
+    val isAnyExerciseCollapsed = pressedExerciseId != null || draggingExerciseId != null
     val exerciseSectionStartIndex = 3
     val reorderableLazyListState = rememberReorderableLazyListState(lazyListState) { from, to ->
         val fromExerciseIndex = from.index - exerciseSectionStartIndex
@@ -313,10 +317,11 @@ private fun SharedTransitionScope.EditWorkoutScreenContent(
                 }
             } else {
                 itemsIndexed(
-                items = exercisesWithSets,
-                key = { _, e -> e.exercise.id }
-            ) { _, exerciseWithSets ->
+                    items = exercisesWithSets,
+                    key = { _, e -> e.exercise.id }
+                ) { _, exerciseWithSets ->
                     ReorderableItem(reorderableLazyListState, key = exerciseWithSets.exercise.id) { isDragging ->
+                        val exerciseId = exerciseWithSets.exercise.id
                         ExerciseCard(
                             modifier = Modifier.animateItem(),
                             animatedVisibilityScope = animatedVisibilityScope,
@@ -332,15 +337,29 @@ private fun SharedTransitionScope.EditWorkoutScreenContent(
                             ) { launchSingleTop = true }
                             },
                             onDelete = deleteExercise,
-                            isDragging = isDragging,
+                            isCollapsed = isAnyExerciseCollapsed || isDragging,
                             showDragHandle = true,
+                            onDragHandlePressedChange = { isPressed ->
+                                if (isPressed) {
+                                    pressedExerciseId = exerciseId
+                                } else if (pressedExerciseId == exerciseId) {
+                                    pressedExerciseId = null
+                                }
+                            },
                             dragHandleModifier = Modifier.draggableHandle(
                                 onDragStarted = {
+                                    draggingExerciseId = exerciseId
                                     hapticFeedback.performHapticFeedback(
                                         HapticFeedbackType.GestureThresholdActivate
                                     )
                                 },
                                 onDragStopped = {
+                                    if (draggingExerciseId == exerciseId) {
+                                        draggingExerciseId = null
+                                    }
+                                    if (pressedExerciseId == exerciseId) {
+                                        pressedExerciseId = null
+                                    }
                                     hapticFeedback.performHapticFeedback(
                                         HapticFeedbackType.GestureEnd
                                     )

--- a/app/src/main/java/org/librefit/ui/screens/editWorkout/EditWorkoutScreen.kt
+++ b/app/src/main/java/org/librefit/ui/screens/editWorkout/EditWorkoutScreen.kt
@@ -20,7 +20,6 @@ import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
-import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Text
@@ -31,15 +30,17 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
-import androidx.compose.ui.hapticfeedback.HapticFeedbackType
-import androidx.compose.ui.platform.LocalHapticFeedback
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.shadow
+import androidx.compose.ui.hapticfeedback.HapticFeedbackType
+import androidx.compose.ui.platform.LocalHapticFeedback
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.AnnotatedString
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.navigation.NavHostController
@@ -196,9 +197,9 @@ private fun SharedTransitionScope.EditWorkoutScreenContent(
     val lazyListState = rememberLazyListState()
     val hapticFeedback = LocalHapticFeedback.current
     // We track the exercise id so a release event from one card can't clear the collapse state while another card is still being pressed or dragged.
-    var pressedExerciseId by remember { mutableStateOf<Long?>(null) }
-    var draggingExerciseId by remember { mutableStateOf<Long?>(null) }
-    val isAnyExerciseCollapsed = pressedExerciseId != null || draggingExerciseId != null
+
+    var isReorderingEnabled by rememberSaveable { mutableStateOf(false) }
+
     val exerciseSectionStartIndex = 3
     val reorderableLazyListState = rememberReorderableLazyListState(lazyListState) { from, to ->
         val fromExerciseIndex = from.index - exerciseSectionStartIndex
@@ -207,6 +208,8 @@ private fun SharedTransitionScope.EditWorkoutScreenContent(
 
         if (fromExerciseIndex in exercisesWithSets.indices && toExerciseIndex in exercisesWithSets.indices) {
             moveExercise(fromExerciseIndex, toExerciseIndex)
+
+            hapticFeedback.performHapticFeedback(HapticFeedbackType.SegmentFrequentTick)
         }
     }
 
@@ -321,9 +324,10 @@ private fun SharedTransitionScope.EditWorkoutScreenContent(
                     key = { _, e -> e.exercise.id }
                 ) { _, exerciseWithSets ->
                     ReorderableItem(reorderableLazyListState, key = exerciseWithSets.exercise.id) { isDragging ->
-                        val exerciseId = exerciseWithSets.exercise.id
                         ExerciseCard(
-                            modifier = Modifier.animateItem(),
+                            modifier = Modifier
+                                .animateItem()
+                                .then(if (isDragging) Modifier.shadow(10.dp) else Modifier),
                             animatedVisibilityScope = animatedVisibilityScope,
                             exerciseWithSets = exerciseWithSets,
                             workout = typeOfEdit == false,
@@ -333,38 +337,21 @@ private fun SharedTransitionScope.EditWorkoutScreenContent(
                                     Route.InfoExerciseScreen(
                                         id,
                                         idExerciseDC
-                                )
-                            ) { launchSingleTop = true }
+                                    )
+                                ) { launchSingleTop = true }
                             },
                             onDelete = deleteExercise,
-                            isCollapsed = isAnyExerciseCollapsed || isDragging,
-                            showDragHandle = true,
-                            onDragHandlePressedChange = { isPressed ->
-                                if (isPressed) {
-                                    pressedExerciseId = exerciseId
-                                } else if (pressedExerciseId == exerciseId) {
-                                    pressedExerciseId = null
-                                }
-                            },
+                            isCollapsed = isReorderingEnabled,
                             dragHandleModifier = Modifier.draggableHandle(
                                 onDragStarted = {
-                                    draggingExerciseId = exerciseId
-                                    hapticFeedback.performHapticFeedback(
-                                        HapticFeedbackType.GestureThresholdActivate
-                                    )
+                                    hapticFeedback.performHapticFeedback(HapticFeedbackType.GestureThresholdActivate)
                                 },
                                 onDragStopped = {
-                                    if (draggingExerciseId == exerciseId) {
-                                        draggingExerciseId = null
-                                    }
-                                    if (pressedExerciseId == exerciseId) {
-                                        pressedExerciseId = null
-                                    }
-                                    hapticFeedback.performHapticFeedback(
-                                        HapticFeedbackType.GestureEnd
-                                    )
+                                    isReorderingEnabled = false
+                                    hapticFeedback.performHapticFeedback(HapticFeedbackType.GestureEnd)
                                 }
                             ),
+                            onReorderRequest = { isReorderingEnabled = true },
                             deleteSet = deleteSet,
                             updateExerciseNotes = updateExerciseNotes,
                             updateExerciseRestTime = updateExerciseRestTime,

--- a/app/src/main/java/org/librefit/ui/screens/editWorkout/EditWorkoutScreen.kt
+++ b/app/src/main/java/org/librefit/ui/screens/editWorkout/EditWorkoutScreen.kt
@@ -316,7 +316,7 @@ private fun SharedTransitionScope.EditWorkoutScreenContent(
                 items = exercisesWithSets,
                 key = { _, e -> e.exercise.id }
             ) { _, exerciseWithSets ->
-                    ReorderableItem(reorderableLazyListState, key = exerciseWithSets.exercise.id) { _ ->
+                    ReorderableItem(reorderableLazyListState, key = exerciseWithSets.exercise.id) { isDragging ->
                         ExerciseCard(
                             modifier = Modifier.animateItem(),
                             animatedVisibilityScope = animatedVisibilityScope,
@@ -328,10 +328,11 @@ private fun SharedTransitionScope.EditWorkoutScreenContent(
                                     Route.InfoExerciseScreen(
                                         id,
                                         idExerciseDC
-                                    )
-                                ) { launchSingleTop = true }
+                                )
+                            ) { launchSingleTop = true }
                             },
                             onDelete = deleteExercise,
+                            isDragging = isDragging,
                             showDragHandle = true,
                             dragHandleModifier = Modifier.draggableHandle(
                                 onDragStarted = {

--- a/app/src/main/java/org/librefit/ui/screens/editWorkout/EditWorkoutScreen.kt
+++ b/app/src/main/java/org/librefit/ui/screens/editWorkout/EditWorkoutScreen.kt
@@ -32,7 +32,6 @@ import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.draw.shadow
 import androidx.compose.ui.hapticfeedback.HapticFeedbackType
 import androidx.compose.ui.platform.LocalHapticFeedback
 import androidx.compose.ui.res.painterResource
@@ -40,7 +39,6 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.AnnotatedString
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
-import androidx.compose.ui.unit.dp
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.navigation.NavHostController
@@ -325,13 +323,12 @@ private fun SharedTransitionScope.EditWorkoutScreenContent(
                 ) { _, exerciseWithSets ->
                     ReorderableItem(reorderableLazyListState, key = exerciseWithSets.exercise.id) { isDragging ->
                         ExerciseCard(
-                            modifier = Modifier
-                                .animateItem()
-                                .then(if (isDragging) Modifier.shadow(10.dp) else Modifier),
+                            modifier = Modifier.animateItem(),
                             animatedVisibilityScope = animatedVisibilityScope,
                             exerciseWithSets = exerciseWithSets,
                             workout = typeOfEdit == false,
                             addSet = addSetToExercise,
+                            isDragging = isDragging,
                             onDetail = { id, idExerciseDC ->
                                 navController.navigate(
                                     Route.InfoExerciseScreen(

--- a/app/src/main/java/org/librefit/ui/screens/editWorkout/EditWorkoutScreen.kt
+++ b/app/src/main/java/org/librefit/ui/screens/editWorkout/EditWorkoutScreen.kt
@@ -17,8 +17,10 @@ import androidx.compose.animation.SharedTransitionScope
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.lazy.itemsIndexed
+import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Text
@@ -29,6 +31,8 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
+import androidx.compose.ui.hapticfeedback.HapticFeedbackType
+import androidx.compose.ui.platform.LocalHapticFeedback
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.painterResource
@@ -62,6 +66,8 @@ import org.librefit.ui.models.UiSet
 import org.librefit.ui.models.UiWorkout
 import org.librefit.ui.screens.shared.SharedViewModel
 import org.librefit.ui.theme.LibreFitTheme
+import sh.calvin.reorderable.ReorderableItem
+import sh.calvin.reorderable.rememberReorderableLazyListState
 
 @OptIn(ExperimentalSharedTransitionApi::class)
 @Composable
@@ -119,6 +125,7 @@ fun SharedTransitionScope.EditWorkoutScreen(
         updateExerciseNotes = viewModel::updateExerciseNotes,
         updateExerciseRestTime = viewModel::updateExerciseRestTime,
         updateExerciseSetMode = viewModel::updateExerciseSetMode,
+        moveExercise = viewModel::moveExercise,
         saveWorkoutWithExercisesInDB = viewModel::saveWorkoutWithExercisesInDB,
     )
 
@@ -146,6 +153,7 @@ private fun SharedTransitionScope.EditWorkoutScreenContent(
     updateExerciseNotes: (String, Long) -> Unit,
     updateExerciseRestTime: (Int, Long) -> Unit,
     updateExerciseSetMode: (SetMode, Long) -> Unit,
+    moveExercise: (Int, Int) -> Unit,
     saveWorkoutWithExercisesInDB: () -> Unit
 ) {
 
@@ -184,6 +192,19 @@ private fun SharedTransitionScope.EditWorkoutScreenContent(
     }
 
     InfoModalBottomSheet(infoMode) { infoMode = InfoMode.DISMISS }
+
+    val lazyListState = rememberLazyListState()
+    val hapticFeedback = LocalHapticFeedback.current
+    val exerciseSectionStartIndex = 3
+    val reorderableLazyListState = rememberReorderableLazyListState(lazyListState) { from, to ->
+        val fromExerciseIndex = from.index - exerciseSectionStartIndex
+        val toExerciseIndex = (to.index - exerciseSectionStartIndex)
+            .coerceIn(0, exercisesWithSets.lastIndex)
+
+        if (fromExerciseIndex in exercisesWithSets.indices && toExerciseIndex in exercisesWithSets.indices) {
+            moveExercise(fromExerciseIndex, toExerciseIndex)
+        }
+    }
 
     LibreFitScaffold(
         title = AnnotatedString(
@@ -229,7 +250,7 @@ private fun SharedTransitionScope.EditWorkoutScreenContent(
         fabDescription = stringResource(R.string.add_exercise),
         fabText = stringResource(R.string.add_exercise),
     ) { innerPadding ->
-        LibreFitLazyColumn(innerPadding) {
+        LibreFitLazyColumn(innerPadding, lazyListState = lazyListState) {
             item {
                 OutlinedTextField(
                     shape = MaterialTheme.shapes.large,
@@ -292,34 +313,49 @@ private fun SharedTransitionScope.EditWorkoutScreenContent(
                 }
             } else {
                 itemsIndexed(
-                    items = exercisesWithSets,
-                    key = { _, e -> e.exercise.id }
-                ) { _, exerciseWithSets ->
-                    ExerciseCard(
-                        modifier = Modifier.animateItem(),
-                        animatedVisibilityScope = animatedVisibilityScope,
-                        exerciseWithSets = exerciseWithSets,
-                        workout = typeOfEdit == false,
-                        addSet = addSetToExercise,
-                        onDetail = { id, idExerciseDC ->
-                            navController.navigate(
-                                Route.InfoExerciseScreen(
-                                    id,
-                                    idExerciseDC
-                                )
-                            ) { launchSingleTop = true }
-                        },
-                        onDelete = deleteExercise,
-                        deleteSet = deleteSet,
-                        updateExerciseNotes = updateExerciseNotes,
-                        updateExerciseRestTime = updateExerciseRestTime,
-                        updateExerciseSetMode = updateExerciseSetMode,
-                        showInfo = onInfoModeChange,
-                        updateSetTime = updateSetTime,
-                        updateSetReps = updateSetReps,
-                        updateSetLoad = updateSetLoad,
-                        updateSetCompleted = updateSetCompleted
-                    )
+                items = exercisesWithSets,
+                key = { _, e -> e.exercise.id }
+            ) { _, exerciseWithSets ->
+                    ReorderableItem(reorderableLazyListState, key = exerciseWithSets.exercise.id) { _ ->
+                        ExerciseCard(
+                            modifier = Modifier.animateItem(),
+                            animatedVisibilityScope = animatedVisibilityScope,
+                            exerciseWithSets = exerciseWithSets,
+                            workout = typeOfEdit == false,
+                            addSet = addSetToExercise,
+                            onDetail = { id, idExerciseDC ->
+                                navController.navigate(
+                                    Route.InfoExerciseScreen(
+                                        id,
+                                        idExerciseDC
+                                    )
+                                ) { launchSingleTop = true }
+                            },
+                            onDelete = deleteExercise,
+                            showDragHandle = true,
+                            dragHandleModifier = Modifier.draggableHandle(
+                                onDragStarted = {
+                                    hapticFeedback.performHapticFeedback(
+                                        HapticFeedbackType.GestureThresholdActivate
+                                    )
+                                },
+                                onDragStopped = {
+                                    hapticFeedback.performHapticFeedback(
+                                        HapticFeedbackType.GestureEnd
+                                    )
+                                }
+                            ),
+                            deleteSet = deleteSet,
+                            updateExerciseNotes = updateExerciseNotes,
+                            updateExerciseRestTime = updateExerciseRestTime,
+                            updateExerciseSetMode = updateExerciseSetMode,
+                            showInfo = onInfoModeChange,
+                            updateSetTime = updateSetTime,
+                            updateSetReps = updateSetReps,
+                            updateSetLoad = updateSetLoad,
+                            updateSetCompleted = updateSetCompleted
+                        )
+                    }
                 }
             }
         }
@@ -381,6 +417,7 @@ private fun EditWorkoutScreenPreview() {
                     updateExerciseNotes = { _, _ -> },
                     updateExerciseRestTime = { _, _ -> },
                     updateExerciseSetMode = { _, _ -> },
+                    moveExercise = { _, _ -> },
                     updateSetTime = { _, _ -> },
                     updateSetReps = { _, _ -> },
                     updateSetLoad = { _, _ -> },

--- a/app/src/main/java/org/librefit/ui/screens/editWorkout/EditWorkoutScreenViewModel.kt
+++ b/app/src/main/java/org/librefit/ui/screens/editWorkout/EditWorkoutScreenViewModel.kt
@@ -31,26 +31,12 @@ import org.librefit.ui.models.UiExercise
 import org.librefit.ui.models.UiExerciseWithSets
 import org.librefit.ui.models.UiSet
 import org.librefit.ui.models.UiWorkout
+import org.librefit.ui.models.moveExercise
+import org.librefit.ui.models.withNormalizedExercisePositions
 import org.librefit.ui.models.mappers.toEntity
 import org.librefit.ui.models.mappers.toUi
 import javax.inject.Inject
 import kotlin.random.Random
-
-internal fun List<UiExerciseWithSets>.withNormalizedExercisePositions(): List<UiExerciseWithSets> {
-    return mapIndexed { index, exerciseWithSets ->
-        exerciseWithSets.copy(exercise = exerciseWithSets.exercise.copy(position = index))
-    }
-}
-
-internal fun List<UiExerciseWithSets>.moveExercise(fromIndex: Int, toIndex: Int): List<UiExerciseWithSets> {
-    if (fromIndex == toIndex || fromIndex !in indices || toIndex !in indices) return this
-
-    return toMutableList()
-        .apply {
-            add(toIndex, removeAt(fromIndex))
-        }
-        .withNormalizedExercisePositions()
-}
 
 @HiltViewModel
 class EditWorkoutScreenViewModel @Inject constructor(

--- a/app/src/main/java/org/librefit/ui/screens/editWorkout/EditWorkoutScreenViewModel.kt
+++ b/app/src/main/java/org/librefit/ui/screens/editWorkout/EditWorkoutScreenViewModel.kt
@@ -36,6 +36,22 @@ import org.librefit.ui.models.mappers.toUi
 import javax.inject.Inject
 import kotlin.random.Random
 
+internal fun List<UiExerciseWithSets>.withNormalizedExercisePositions(): List<UiExerciseWithSets> {
+    return mapIndexed { index, exerciseWithSets ->
+        exerciseWithSets.copy(exercise = exerciseWithSets.exercise.copy(position = index))
+    }
+}
+
+internal fun List<UiExerciseWithSets>.moveExercise(fromIndex: Int, toIndex: Int): List<UiExerciseWithSets> {
+    if (fromIndex == toIndex || fromIndex !in indices || toIndex !in indices) return this
+
+    return toMutableList()
+        .apply {
+            add(toIndex, removeAt(fromIndex))
+        }
+        .withNormalizedExercisePositions()
+}
+
 @HiltViewModel
 class EditWorkoutScreenViewModel @Inject constructor(
     savedStateHandle: SavedStateHandle,
@@ -111,7 +127,7 @@ class EditWorkoutScreenViewModel @Inject constructor(
         )
 
         _exercises.update { exercises ->
-            exercises + newExercise
+            (exercises + newExercise).withNormalizedExercisePositions()
         }
     }
 
@@ -224,7 +240,15 @@ class EditWorkoutScreenViewModel @Inject constructor(
 
     fun deleteExercise(exerciseId: Long) {
         _exercises.update { currentExercises ->
-            currentExercises.filter { it.exercise.id != exerciseId }
+            currentExercises
+                .filter { it.exercise.id != exerciseId }
+                .withNormalizedExercisePositions()
+        }
+    }
+
+    fun moveExercise(fromIndex: Int, toIndex: Int) {
+        _exercises.update { currentExercises ->
+            currentExercises.moveExercise(fromIndex = fromIndex, toIndex = toIndex)
         }
     }
 
@@ -253,7 +277,9 @@ class EditWorkoutScreenViewModel @Inject constructor(
             workoutRepository.addWorkoutWithExercisesAndSets(
                 WorkoutWithExercisesAndSets(
                     workout = workout.value.copy(state = state).toEntity(),
-                    exercisesWithSets = exercises.value.map { it.toEntity() }
+                    exercisesWithSets = exercises.value
+                        .withNormalizedExercisePositions()
+                        .map { it.toEntity() }
                 )
             )
         }
@@ -268,4 +294,3 @@ class EditWorkoutScreenViewModel @Inject constructor(
         return if (workout.value.id == 0L) null else isRoutine.value
     }
 }
-

--- a/app/src/main/java/org/librefit/ui/screens/workout/WorkoutScreen.kt
+++ b/app/src/main/java/org/librefit/ui/screens/workout/WorkoutScreen.kt
@@ -307,6 +307,10 @@ private fun SharedTransitionScope.WorkoutScreenContent(
 ) {
     val lazyListState = rememberLazyListState()
     val hapticFeedback = LocalHapticFeedback.current
+    // We track the exercise id so a release event from one card can't clear the collapse state while another card is still being pressed or dragged.
+    var pressedExerciseId by remember { mutableStateOf<Long?>(null) }
+    var draggingExerciseId by remember { mutableStateOf<Long?>(null) }
+    val isAnyExerciseCollapsed = pressedExerciseId != null || draggingExerciseId != null
     val exerciseSectionStartIndex = 1
     val reorderableLazyListState = rememberReorderableLazyListState(lazyListState) { from, to ->
         val fromExerciseIndex = from.index - exerciseSectionStartIndex
@@ -400,6 +404,7 @@ private fun SharedTransitionScope.WorkoutScreenContent(
                 key = { _, exercise -> exercise.exercise.id }
             ) { i, exerciseWithSets ->
                 ReorderableItem(reorderableLazyListState, key = exerciseWithSets.exercise.id) { isDragging ->
+                    val exerciseId = exerciseWithSets.exercise.id
                     ExerciseCard(
                         modifier = Modifier.animateItem(),
                         animatedVisibilityScope = animatedVisibilityScope,
@@ -410,15 +415,29 @@ private fun SharedTransitionScope.WorkoutScreenContent(
                         addSet = addSetToExercise,
                         onDetail = onSelectedExerciseIdChange,
                         onDelete = deleteExercise,
-                        isDragging = isDragging,
+                        isCollapsed = isAnyExerciseCollapsed || isDragging,
                         showDragHandle = true,
+                        onDragHandlePressedChange = { isPressed ->
+                            if (isPressed) {
+                                pressedExerciseId = exerciseId
+                            } else if (pressedExerciseId == exerciseId) {
+                                pressedExerciseId = null
+                            }
+                        },
                         dragHandleModifier = Modifier.draggableHandle(
                             onDragStarted = {
+                                draggingExerciseId = exerciseId
                                 hapticFeedback.performHapticFeedback(
                                     HapticFeedbackType.GestureThresholdActivate
                                 )
                             },
                             onDragStopped = {
+                                if (draggingExerciseId == exerciseId) {
+                                    draggingExerciseId = null
+                                }
+                                if (pressedExerciseId == exerciseId) {
+                                    pressedExerciseId = null
+                                }
                                 hapticFeedback.performHapticFeedback(
                                     HapticFeedbackType.GestureEnd
                                 )

--- a/app/src/main/java/org/librefit/ui/screens/workout/WorkoutScreen.kt
+++ b/app/src/main/java/org/librefit/ui/screens/workout/WorkoutScreen.kt
@@ -29,6 +29,7 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.lazy.LazyItemScope
 import androidx.compose.foundation.lazy.itemsIndexed
+import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.material3.ButtonGroup
 import androidx.compose.material3.CircularWavyProgressIndicator
 import androidx.compose.material3.ElevatedCard
@@ -53,9 +54,12 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.hapticfeedback.HapticFeedbackType
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.LocalHapticFeedback
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.AnnotatedString
@@ -92,6 +96,8 @@ import org.librefit.ui.models.UiSet
 import org.librefit.ui.screens.shared.SharedViewModel
 import org.librefit.ui.theme.LibreFitTheme
 import org.librefit.util.Formatter
+import sh.calvin.reorderable.ReorderableItem
+import sh.calvin.reorderable.rememberReorderableLazyListState
 
 @OptIn(ExperimentalSharedTransitionApi::class)
 @Composable
@@ -233,6 +239,7 @@ fun SharedTransitionScope.WorkoutScreen(
                 deleteExercise = { id ->
                     idExerciseToDelete.value = id
                 },
+                moveExercise = viewModel::moveExercise,
                 showInfo = { infoMode.value = it },
                 applyPreviousSetPerformance = viewModel::applyPreviousSetPerformance
             )
@@ -293,11 +300,25 @@ private fun SharedTransitionScope.WorkoutScreenContent(
     updateExerciseRestTime: (Int, Long) -> Unit,
     updateExerciseSetMode: (SetMode, Long) -> Unit,
     deleteExercise: (Long) -> Unit,
+    moveExercise: (Int, Int) -> Unit,
     onSelectedExerciseIdChange: (Long, String) -> Unit,
     showInfo: (InfoMode) -> Unit,
     applyPreviousSetPerformance: (Long) -> Unit
 ) {
-    LibreFitLazyColumn {
+    val lazyListState = rememberLazyListState()
+    val hapticFeedback = LocalHapticFeedback.current
+    val exerciseSectionStartIndex = 1
+    val reorderableLazyListState = rememberReorderableLazyListState(lazyListState) { from, to ->
+        val fromExerciseIndex = from.index - exerciseSectionStartIndex
+        val toExerciseIndex = (to.index - exerciseSectionStartIndex)
+            .coerceIn(0, exercisesWithSets.lastIndex)
+
+        if (fromExerciseIndex in exercisesWithSets.indices && toExerciseIndex in exercisesWithSets.indices) {
+            moveExercise(fromExerciseIndex, toExerciseIndex)
+        }
+    }
+
+    LibreFitLazyColumn(lazyListState = lazyListState) {
         val headerContent: @Composable LazyItemScope.() -> Unit = {
             ElevatedCard(shape = MaterialTheme.shapes.extraLargeIncreased) {
                 Column(
@@ -378,28 +399,43 @@ private fun SharedTransitionScope.WorkoutScreenContent(
                 items = exercisesWithSets,
                 key = { _, exercise -> exercise.exercise.id }
             ) { i, exerciseWithSets ->
-                ExerciseCard(
-                    modifier = Modifier.animateItem(),
-                    animatedVisibilityScope = animatedVisibilityScope,
-                    exerciseWithSets = exerciseWithSets,
-                    previousPerformances = previousPerformances.getOrNull(i),
-                    idSetWithRunningStopwatch = idSetWithRunningStopwatch,
-                    workout = true,
-                    addSet = addSetToExercise,
-                    onDetail = onSelectedExerciseIdChange,
-                    onDelete = deleteExercise,
-                    deleteSet = deleteSet,
-                    showInfo = showInfo,
-                    updateIdSetWithRunningStopwatch = updateIdSetWithRunningStopwatch,
-                    updateExerciseNotes = updateExerciseNotes,
-                    updateExerciseRestTime = updateExerciseRestTime,
-                    updateExerciseSetMode = updateExerciseSetMode,
-                    updateSetTime = updateSetTime,
-                    updateSetReps = updateSetReps,
-                    updateSetLoad = updateSetLoad,
-                    updateSetCompleted = updateSetCompleted,
-                    applyPreviousSetPerformance = applyPreviousSetPerformance
-                )
+                ReorderableItem(reorderableLazyListState, key = exerciseWithSets.exercise.id) { _ ->
+                    ExerciseCard(
+                        modifier = Modifier.animateItem(),
+                        animatedVisibilityScope = animatedVisibilityScope,
+                        exerciseWithSets = exerciseWithSets,
+                        previousPerformances = previousPerformances.getOrNull(i),
+                        idSetWithRunningStopwatch = idSetWithRunningStopwatch,
+                        workout = true,
+                        addSet = addSetToExercise,
+                        onDetail = onSelectedExerciseIdChange,
+                        onDelete = deleteExercise,
+                        showDragHandle = true,
+                        dragHandleModifier = Modifier.draggableHandle(
+                            onDragStarted = {
+                                hapticFeedback.performHapticFeedback(
+                                    HapticFeedbackType.GestureThresholdActivate
+                                )
+                            },
+                            onDragStopped = {
+                                hapticFeedback.performHapticFeedback(
+                                    HapticFeedbackType.GestureEnd
+                                )
+                            }
+                        ),
+                        deleteSet = deleteSet,
+                        showInfo = showInfo,
+                        updateIdSetWithRunningStopwatch = updateIdSetWithRunningStopwatch,
+                        updateExerciseNotes = updateExerciseNotes,
+                        updateExerciseRestTime = updateExerciseRestTime,
+                        updateExerciseSetMode = updateExerciseSetMode,
+                        updateSetTime = updateSetTime,
+                        updateSetReps = updateSetReps,
+                        updateSetLoad = updateSetLoad,
+                        updateSetCompleted = updateSetCompleted,
+                        applyPreviousSetPerformance = applyPreviousSetPerformance
+                    )
+                }
             }
         }
     }
@@ -620,6 +656,7 @@ private fun WorkoutScreenPreview() {
                             updateExerciseRestTime = { _, _ -> },
                             updateExerciseSetMode = { _, _ -> },
                             deleteExercise = {},
+                            moveExercise = { _, _ -> },
                             onSelectedExerciseIdChange = { _, _ -> },
                             showInfo = {},
                             applyPreviousSetPerformance = {}

--- a/app/src/main/java/org/librefit/ui/screens/workout/WorkoutScreen.kt
+++ b/app/src/main/java/org/librefit/ui/screens/workout/WorkoutScreen.kt
@@ -57,6 +57,7 @@ import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.shadow
 import androidx.compose.ui.hapticfeedback.HapticFeedbackType
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalHapticFeedback
@@ -307,15 +308,16 @@ private fun SharedTransitionScope.WorkoutScreenContent(
 ) {
     val lazyListState = rememberLazyListState()
     val hapticFeedback = LocalHapticFeedback.current
-    // We track the exercise id so a release event from one card can't clear the collapse state while another card is still being pressed or dragged.
-    var pressedExerciseId by remember { mutableStateOf<Long?>(null) }
-    var draggingExerciseId by remember { mutableStateOf<Long?>(null) }
-    val isAnyExerciseCollapsed = pressedExerciseId != null || draggingExerciseId != null
+
+    var isReorderingEnabled by rememberSaveable { mutableStateOf(false) }
+
     val exerciseSectionStartIndex = 1
     val reorderableLazyListState = rememberReorderableLazyListState(lazyListState) { from, to ->
         val fromExerciseIndex = from.index - exerciseSectionStartIndex
         val toExerciseIndex = (to.index - exerciseSectionStartIndex)
             .coerceIn(0, exercisesWithSets.lastIndex)
+
+        hapticFeedback.performHapticFeedback(HapticFeedbackType.SegmentFrequentTick)
 
         if (fromExerciseIndex in exercisesWithSets.indices && toExerciseIndex in exercisesWithSets.indices) {
             moveExercise(fromExerciseIndex, toExerciseIndex)
@@ -404,9 +406,10 @@ private fun SharedTransitionScope.WorkoutScreenContent(
                 key = { _, exercise -> exercise.exercise.id }
             ) { i, exerciseWithSets ->
                 ReorderableItem(reorderableLazyListState, key = exerciseWithSets.exercise.id) { isDragging ->
-                    val exerciseId = exerciseWithSets.exercise.id
                     ExerciseCard(
-                        modifier = Modifier.animateItem(),
+                        modifier = Modifier
+                            .animateItem()
+                            .then(if (isDragging) Modifier.shadow(10.dp) else Modifier),
                         animatedVisibilityScope = animatedVisibilityScope,
                         exerciseWithSets = exerciseWithSets,
                         previousPerformances = previousPerformances.getOrNull(i),
@@ -415,34 +418,17 @@ private fun SharedTransitionScope.WorkoutScreenContent(
                         addSet = addSetToExercise,
                         onDetail = onSelectedExerciseIdChange,
                         onDelete = deleteExercise,
-                        isCollapsed = isAnyExerciseCollapsed || isDragging,
-                        showDragHandle = true,
-                        onDragHandlePressedChange = { isPressed ->
-                            if (isPressed) {
-                                pressedExerciseId = exerciseId
-                            } else if (pressedExerciseId == exerciseId) {
-                                pressedExerciseId = null
-                            }
-                        },
+                        isCollapsed = isReorderingEnabled,
                         dragHandleModifier = Modifier.draggableHandle(
                             onDragStarted = {
-                                draggingExerciseId = exerciseId
-                                hapticFeedback.performHapticFeedback(
-                                    HapticFeedbackType.GestureThresholdActivate
-                                )
+                                hapticFeedback.performHapticFeedback(HapticFeedbackType.GestureThresholdActivate)
                             },
                             onDragStopped = {
-                                if (draggingExerciseId == exerciseId) {
-                                    draggingExerciseId = null
-                                }
-                                if (pressedExerciseId == exerciseId) {
-                                    pressedExerciseId = null
-                                }
-                                hapticFeedback.performHapticFeedback(
-                                    HapticFeedbackType.GestureEnd
-                                )
+                                isReorderingEnabled = false
+                                hapticFeedback.performHapticFeedback(HapticFeedbackType.GestureEnd)
                             }
                         ),
+                        onReorderRequest = { isReorderingEnabled = true },
                         deleteSet = deleteSet,
                         showInfo = showInfo,
                         updateIdSetWithRunningStopwatch = updateIdSetWithRunningStopwatch,

--- a/app/src/main/java/org/librefit/ui/screens/workout/WorkoutScreen.kt
+++ b/app/src/main/java/org/librefit/ui/screens/workout/WorkoutScreen.kt
@@ -399,7 +399,7 @@ private fun SharedTransitionScope.WorkoutScreenContent(
                 items = exercisesWithSets,
                 key = { _, exercise -> exercise.exercise.id }
             ) { i, exerciseWithSets ->
-                ReorderableItem(reorderableLazyListState, key = exerciseWithSets.exercise.id) { _ ->
+                ReorderableItem(reorderableLazyListState, key = exerciseWithSets.exercise.id) { isDragging ->
                     ExerciseCard(
                         modifier = Modifier.animateItem(),
                         animatedVisibilityScope = animatedVisibilityScope,
@@ -410,6 +410,7 @@ private fun SharedTransitionScope.WorkoutScreenContent(
                         addSet = addSetToExercise,
                         onDetail = onSelectedExerciseIdChange,
                         onDelete = deleteExercise,
+                        isDragging = isDragging,
                         showDragHandle = true,
                         dragHandleModifier = Modifier.draggableHandle(
                             onDragStarted = {

--- a/app/src/main/java/org/librefit/ui/screens/workout/WorkoutScreen.kt
+++ b/app/src/main/java/org/librefit/ui/screens/workout/WorkoutScreen.kt
@@ -57,7 +57,6 @@ import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.draw.shadow
 import androidx.compose.ui.hapticfeedback.HapticFeedbackType
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalHapticFeedback
@@ -407,9 +406,7 @@ private fun SharedTransitionScope.WorkoutScreenContent(
             ) { i, exerciseWithSets ->
                 ReorderableItem(reorderableLazyListState, key = exerciseWithSets.exercise.id) { isDragging ->
                     ExerciseCard(
-                        modifier = Modifier
-                            .animateItem()
-                            .then(if (isDragging) Modifier.shadow(10.dp) else Modifier),
+                        modifier = Modifier.animateItem(),
                         animatedVisibilityScope = animatedVisibilityScope,
                         exerciseWithSets = exerciseWithSets,
                         previousPerformances = previousPerformances.getOrNull(i),
@@ -428,6 +425,7 @@ private fun SharedTransitionScope.WorkoutScreenContent(
                                 hapticFeedback.performHapticFeedback(HapticFeedbackType.GestureEnd)
                             }
                         ),
+                        isDragging = isDragging,
                         onReorderRequest = { isReorderingEnabled = true },
                         deleteSet = deleteSet,
                         showInfo = showInfo,

--- a/app/src/main/java/org/librefit/ui/screens/workout/WorkoutScreenViewModel.kt
+++ b/app/src/main/java/org/librefit/ui/screens/workout/WorkoutScreenViewModel.kt
@@ -51,6 +51,8 @@ import org.librefit.ui.models.UiExercise
 import org.librefit.ui.models.UiExerciseWithSets
 import org.librefit.ui.models.UiSet
 import org.librefit.ui.models.UiWorkout
+import org.librefit.ui.models.moveExercise
+import org.librefit.ui.models.withNormalizedExercisePositions
 import org.librefit.ui.models.mappers.toEntity
 import org.librefit.ui.models.mappers.toUi
 import javax.inject.Inject
@@ -269,7 +271,7 @@ class WorkoutScreenViewModel @Inject constructor(
         )
 
         _exercises.update { exercises ->
-            exercises + newExercise
+            (exercises + newExercise).withNormalizedExercisePositions()
         }
     }
 
@@ -403,7 +405,15 @@ class WorkoutScreenViewModel @Inject constructor(
             _idSetWithRunningStopwatch.update { 0L }
         }
         _exercises.update { currentExercises ->
-            currentExercises.filter { it.exercise.id != exerciseId }
+            currentExercises
+                .filter { it.exercise.id != exerciseId }
+                .withNormalizedExercisePositions()
+        }
+    }
+
+    fun moveExercise(fromIndex: Int, toIndex: Int) {
+        _exercises.update { currentExercises ->
+            currentExercises.moveExercise(fromIndex = fromIndex, toIndex = toIndex)
         }
     }
 
@@ -515,7 +525,9 @@ class WorkoutScreenViewModel @Inject constructor(
                         state = WorkoutState.RUNNING,
                         timeElapsed = t
                     ).toEntity(),
-                    exercisesWithSets = e.map { it.toEntity() },
+                    exercisesWithSets = e
+                        .withNormalizedExercisePositions()
+                        .map { it.toEntity() },
                 )
             )
         }

--- a/app/src/main/res/drawable/ic_drag_handle.xml
+++ b/app/src/main/res/drawable/ic_drag_handle.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="#FF000000"
+        android:pathData="M20,9H4V7h16zM4,17h16v-2H4z" />
+</vector>

--- a/app/src/main/res/drawable/ic_more_options.xml
+++ b/app/src/main/res/drawable/ic_more_options.xml
@@ -1,0 +1,17 @@
+<!--
+  ~ SPDX-License-Identifier: GPL-3.0-or-later
+  ~ Copyright (c) 2026. The LibreFit Contributors
+  ~
+  ~ LibreFit is subject to additional terms covering author attribution and trademark usage;
+  ~ see the ADDITIONAL_TERMS.md and TRADEMARK_POLICY.md files in the project root.
+  -->
+
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="960"
+    android:viewportHeight="960">
+    <path
+        android:fillColor="#e3e3e3"
+        android:pathData="M480,800q-33,0 -56.5,-23.5T400,720q0,-33 23.5,-56.5T480,640q33,0 56.5,23.5T560,720q0,33 -23.5,56.5T480,800ZM480,560q-33,0 -56.5,-23.5T400,480q0,-33 23.5,-56.5T480,400q33,0 56.5,23.5T560,480q0,33 -23.5,56.5T480,560ZM480,320q-33,0 -56.5,-23.5T400,240q0,-33 23.5,-56.5T480,160q33,0 56.5,23.5T560,240q0,33 -23.5,56.5T480,320Z" />
+</vector>

--- a/app/src/main/res/drawable/ic_reorder.xml
+++ b/app/src/main/res/drawable/ic_reorder.xml
@@ -1,0 +1,17 @@
+<!--
+  ~ SPDX-License-Identifier: GPL-3.0-or-later
+  ~ Copyright (c) 2026. The LibreFit Contributors
+  ~
+  ~ LibreFit is subject to additional terms covering author attribution and trademark usage;
+  ~ see the ADDITIONAL_TERMS.md and TRADEMARK_POLICY.md files in the project root.
+  -->
+
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="960"
+    android:viewportHeight="960">
+    <path
+        android:fillColor="#e3e3e3"
+        android:pathData="M120,760v-80h720v80L120,760ZM120,600v-80h720v80L120,600ZM120,440v-80h720v80L120,440ZM120,280v-80h720v80L120,280Z" />
+</vector>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -94,6 +94,7 @@
     <string name="edit_workout">Edit workout</string>
     <string name="quit_routine_creation_question">Quit routine creation?</string>
     <string name="warning_delete_exercise_from_routine">Warning! Deleting exercises from existing routines will unlink all exercises of derivative workouts.</string>
+    <string name="reorder">Reorder</string>
 
 
     <!-- Error screen-->
@@ -102,7 +103,6 @@
     <string name="crash_log">Crash log</string>
     <string name="report_github">Report on GitHub</string>
     <string name="url_github_search_issue" translatable="false">https://github.com/LibreFitOrg/LibreFit/issues?q=</string>
-    <string name="reorder">Reorder</string>
     <string name="stack_trace_not_available">Stack trace not available</string>
 
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -102,6 +102,7 @@
     <string name="crash_log">Crash log</string>
     <string name="report_github">Report on GitHub</string>
     <string name="url_github_search_issue" translatable="false">https://github.com/LibreFitOrg/LibreFit/issues?q=</string>
+    <string name="reorder">Reorder</string>
     <string name="stack_trace_not_available">Stack trace not available</string>
 
 

--- a/app/src/test/java/org/librefit/ui/screens/editWorkout/EditWorkoutScreenViewModelTest.kt
+++ b/app/src/test/java/org/librefit/ui/screens/editWorkout/EditWorkoutScreenViewModelTest.kt
@@ -12,6 +12,8 @@ import com.google.common.truth.Truth.assertThat
 import org.junit.Test
 import org.librefit.ui.models.UiExercise
 import org.librefit.ui.models.UiExerciseWithSets
+import org.librefit.ui.models.moveExercise
+import org.librefit.ui.models.withNormalizedExercisePositions
 
 class EditWorkoutScreenViewModelTest {
 

--- a/app/src/test/java/org/librefit/ui/screens/editWorkout/EditWorkoutScreenViewModelTest.kt
+++ b/app/src/test/java/org/librefit/ui/screens/editWorkout/EditWorkoutScreenViewModelTest.kt
@@ -1,0 +1,49 @@
+/*
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ * Copyright (c) 2025-2026. The LibreFit Contributors
+ *
+ * LibreFit is subject to additional terms covering author attribution and trademark usage;
+ * see the ADDITIONAL_TERMS.md and TRADEMARK_POLICY.md files in the project root.
+ */
+
+package org.librefit.ui.screens.editWorkout
+
+import com.google.common.truth.Truth.assertThat
+import org.junit.Test
+import org.librefit.ui.models.UiExercise
+import org.librefit.ui.models.UiExerciseWithSets
+
+class EditWorkoutScreenViewModelTest {
+
+    private val exercises = listOf(
+        UiExerciseWithSets(exercise = UiExercise(id = 11L, position = 0)),
+        UiExerciseWithSets(exercise = UiExercise(id = 22L, position = 1)),
+        UiExerciseWithSets(exercise = UiExercise(id = 33L, position = 2))
+    )
+
+    @Test
+    fun `moveExercise reorders list and rewrites positions`() {
+        val reordered = exercises.moveExercise(fromIndex = 0, toIndex = 2)
+
+        assertThat(reordered.map { it.exercise.id }).containsExactly(22L, 33L, 11L).inOrder()
+        assertThat(reordered.map { it.exercise.position }).containsExactly(0, 1, 2).inOrder()
+    }
+
+    @Test
+    fun `moveExercise ignores invalid indices`() {
+        val reordered = exercises.moveExercise(fromIndex = -1, toIndex = 2)
+
+        assertThat(reordered).isEqualTo(exercises)
+    }
+
+    @Test
+    fun `withNormalizedExercisePositions rewrites positions sequentially`() {
+        val normalized = listOf(
+            UiExerciseWithSets(exercise = UiExercise(id = 22L, position = 99)),
+            UiExerciseWithSets(exercise = UiExercise(id = 11L, position = 44))
+        ).withNormalizedExercisePositions()
+
+        assertThat(normalized.map { it.exercise.id }).containsExactly(22L, 11L).inOrder()
+        assertThat(normalized.map { it.exercise.position }).containsExactly(0, 1).inOrder()
+    }
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -23,6 +23,7 @@ mockk = "1.14.9"
 kotlinxCollectionsImmutable = "0.4.0"
 material = "1.14.0-alpha09"
 coil = "3.4.0"
+reorderable = "3.0.0"
 
 [libraries]
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version = "1.17.0" }
@@ -63,6 +64,7 @@ mockk-agent = { group = "io.mockk", name = "mockk-agent", version.ref = "mockk" 
 kotlinx-collections-immutable = { group = "org.jetbrains.kotlinx", name = "kotlinx-collections-immutable", version.ref = "kotlinxCollectionsImmutable" }
 material = { group = "com.google.android.material", name = "material", version.ref = "material" }
 coil = { group = "io.coil-kt.coil3", name = "coil-compose", version.ref = "coil" }
+reorderable = { module = "sh.calvin.reorderable:reorderable", version.ref = "reorderable" }
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }


### PR DESCRIPTION
Adds a drag handle to reorder exercises around by dragging them up or down.
Used https://github.com/Calvin-LL/Reorderable as #4 pointed at.
Had to change the database schema to include the position of the exercise in the routine / workout, as previous behavior relied just on the original insert order upon creation of the routine / workout