### PR TITLE
Add initial Health Connect measurements export

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -189,6 +189,7 @@ dependencies {
     implementation(libs.hilt.android)
     ksp(libs.hilt.android.compiler)
     implementation(libs.androidx.hilt.navigation.compose)
+    implementation(libs.androidx.health.connect)
 
 
     // AboutLibraries to show used dependencies in jetpack compose

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -10,12 +10,15 @@
     xmlns:tools="http://schemas.android.com/tools">
 
     <queries>
+        <package android:name="com.google.android.apps.healthdata" />
         <package android:name="org.librefit.companion" />
     </queries>
 
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE_DATA_SYNC" />
+    <uses-permission android:name="android.permission.health.WRITE_BODY_FAT" />
+    <uses-permission android:name="android.permission.health.WRITE_WEIGHT" />
 
     <application
         android:allowBackup="true"
@@ -54,8 +57,18 @@
                 <action android:name="android.intent.action.VIEW_PERMISSION_USAGE_FOR_PERIOD" />
 
                 <category android:name="android.intent.category.DEFAULT" />
+                <category android:name="android.intent.category.HEALTH_PERMISSIONS" />
             </intent-filter>
         </activity>
+
+        <activity-alias
+            android:name=".activities.HealthPermissionsRationaleActivity"
+            android:targetActivity=".activities.PrivacyActivity"
+            android:exported="true">
+            <intent-filter>
+                <action android:name="androidx.health.ACTION_SHOW_PERMISSIONS_RATIONALE" />
+            </intent-filter>
+        </activity-alias>
 
         <activity
             android:name=".activities.ErrorActivity"

--- a/app/src/main/java/org/librefit/health/HealthConnectRepository.kt
+++ b/app/src/main/java/org/librefit/health/HealthConnectRepository.kt
@@ -1,0 +1,101 @@
+/*
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ * Copyright (c) 2026. The LibreFit Contributors
+ *
+ * LibreFit is subject to additional terms covering author attribution and trademark usage;
+ * see the ADDITIONAL_TERMS.md and TRADEMARK_POLICY.md files in the project root.
+ */
+
+package org.librefit.health
+
+import android.content.Context
+import androidx.health.connect.client.HealthConnectClient
+import androidx.health.connect.client.HealthConnectClient.Companion.SDK_AVAILABLE
+import androidx.health.connect.client.permission.HealthPermission
+import androidx.health.connect.client.records.BodyFatRecord
+import androidx.health.connect.client.records.Record
+import androidx.health.connect.client.records.WeightRecord
+import androidx.health.connect.client.records.metadata.Metadata
+import androidx.health.connect.client.units.Mass
+import androidx.health.connect.client.units.Percentage
+import dagger.hilt.android.qualifiers.ApplicationContext
+import org.librefit.db.entity.Measurement
+import java.time.ZoneId
+import javax.inject.Inject
+import javax.inject.Singleton
+
+@Singleton
+class HealthConnectRepository @Inject constructor(
+    @param:ApplicationContext private val context: Context
+) {
+    val writePermissions: Set<String> = setOf(
+        HealthPermission.getWritePermission(BodyFatRecord::class),
+        HealthPermission.getWritePermission(WeightRecord::class)
+    )
+
+    private val healthConnectClient: HealthConnectClient by lazy {
+        HealthConnectClient.getOrCreate(context)
+    }
+
+    fun isAvailable(): Boolean {
+        return HealthConnectClient.getSdkStatus(context) == SDK_AVAILABLE
+    }
+
+    suspend fun hasWritePermissions(): Boolean {
+        if (!isAvailable()) return false
+
+        return healthConnectClient.permissionController
+            .getGrantedPermissions()
+            .containsAll(writePermissions)
+    }
+
+    suspend fun exportMeasurements(measurements: List<Measurement>): Int {
+        if (!hasWritePermissions()) {
+            throw SecurityException("Missing Health Connect write permissions")
+        }
+
+        val records = measurements.flatMap { it.toHealthConnectRecords() }
+        if (records.isEmpty()) return 0
+
+        healthConnectClient.insertRecords(records)
+        return records.size
+    }
+
+    private fun Measurement.toHealthConnectRecords(): List<Record> {
+        val zone = ZoneId.systemDefault()
+        val zonedDate = date.atZone(zone)
+        val instant = zonedDate.toInstant()
+        val zoneOffset = zonedDate.offset
+        val recordVersion = instant.toEpochMilli()
+
+        return buildList {
+            if (bodyWeight > 0.0) {
+                add(
+                    WeightRecord(
+                        metadata = Metadata.manualEntry(
+                            clientRecordId = "librefit-measurement-$id-body-weight",
+                            clientRecordVersion = recordVersion
+                        ),
+                        time = instant,
+                        zoneOffset = zoneOffset,
+                        weight = Mass.kilograms(bodyWeight)
+                    )
+                )
+            }
+
+            if (bodyFatPercentage > 0) {
+                add(
+                    BodyFatRecord(
+                        metadata = Metadata.manualEntry(
+                            clientRecordId = "librefit-measurement-$id-body-fat",
+                            clientRecordVersion = recordVersion
+                        ),
+                        time = instant,
+                        zoneOffset = zoneOffset,
+                        percentage = Percentage(bodyFatPercentage.toDouble())
+                    )
+                )
+            }
+        }
+    }
+}

--- a/app/src/main/java/org/librefit/ui/screens/about/PrivacyScreen.kt
+++ b/app/src/main/java/org/librefit/ui/screens/about/PrivacyScreen.kt
@@ -66,6 +66,7 @@ fun PrivacyScreen(
                     stringResource(R.string.privacy_notice_summary)
                             + "\n\n## " + stringResource(R.string.privacy_notice_optional_perm)
                             + "\n\n" + stringResource(R.string.privacy_notice_notification_perm)
+                            + "\n\n" + stringResource(R.string.privacy_notice_health_connect_perm)
                             + "\n\n## " + stringResource(R.string.privacy_notice_default_perm)
                             + "\n\n" + stringResource(R.string.privacy_notice_foreground_perm)
                 )

--- a/app/src/main/java/org/librefit/ui/screens/settings/SettingsScreen.kt
+++ b/app/src/main/java/org/librefit/ui/screens/settings/SettingsScreen.kt
@@ -9,6 +9,8 @@
 package org.librefit.ui.screens.settings
 
 import android.os.Build
+import androidx.activity.compose.rememberLauncherForActivityResult
+import androidx.health.connect.client.PermissionController
 import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.ExperimentalSharedTransitionApi
 import androidx.compose.animation.animateContentSize
@@ -90,6 +92,14 @@ fun SettingsScreen(
 
     val dismissScrollWheelInputAutomatically by viewModel.dismissScrollWheelInputAutomatically.collectAsStateWithLifecycle()
 
+    val healthConnectState by viewModel.healthConnectState.collectAsStateWithLifecycle()
+
+    val healthConnectPermissionLauncher = rememberLauncherForActivityResult(
+        contract = PermissionController.createRequestPermissionResultContract()
+    ) { grantedPermissions ->
+        viewModel.updateHealthConnectPermissions(grantedPermissions)
+    }
+
     preferences?.let {
         PreferenceDialog(
             currentPreference = currentPreference,
@@ -109,6 +119,7 @@ fun SettingsScreen(
         keepWorkoutScreenOn = keepWorkoutScreenOn,
         restTimerSoundOn = restTimerSoundOn,
         isSupporter = isSupporter,
+        healthConnectState = healthConnectState,
         useScrollWheelForInput = useScrollWheelForInput,
         isWorkoutHeaderSticky = isWorkoutHeaderSticky,
         dismissScrollWheelInputAutomatically = dismissScrollWheelInputAutomatically,
@@ -118,6 +129,15 @@ fun SettingsScreen(
         onRestTimerSoundOnChange = viewModel::saveRestTimerSoundOn,
         onIsWorkoutHeaderStickyChange = viewModel::saveIsWorkoutHeaderSticky,
         onUseScrollWheelForInputChange = viewModel::saveUseScrollWheelForInput,
+        onHealthConnectClick = {
+            when {
+                !healthConnectState.isAvailable -> Unit
+                !healthConnectState.hasPermissions -> {
+                    healthConnectPermissionLauncher.launch(viewModel.healthConnectPermissions)
+                }
+                else -> viewModel.exportMeasurementsToHealthConnect()
+            }
+        },
         onDismissScrollWhellInputAutomaticallyChange = viewModel::saveDismissScrollWheelInputAutomatically
     )
 }
@@ -132,6 +152,7 @@ private fun SettingsScreenContent(
     keepWorkoutScreenOn: Boolean,
     restTimerSoundOn: Boolean,
     isSupporter: Boolean,
+    healthConnectState: HealthConnectState,
     isWorkoutHeaderSticky: Boolean,
     useScrollWheelForInput: Boolean,
     dismissScrollWheelInputAutomatically: Boolean,
@@ -141,6 +162,7 @@ private fun SettingsScreenContent(
     onRestTimerSoundOnChange: (Boolean) -> Unit,
     onIsWorkoutHeaderStickyChange: (Boolean) -> Unit,
     onUseScrollWheelForInputChange: (Boolean) -> Unit,
+    onHealthConnectClick: () -> Unit,
     onDismissScrollWhellInputAutomaticallyChange: (Boolean) -> Unit,
 ) {
     LibreFitScaffold(
@@ -221,6 +243,37 @@ private fun SettingsScreenContent(
                 )
             }
 
+            item { HeadlineText(text = stringResource(id = R.string.integrations)) }
+
+            item {
+                SettingItem(
+                    enabled = healthConnectState.isAvailable && !healthConnectState.isExporting,
+                    onClick = onHealthConnectClick,
+                    icon = painterResource(R.drawable.ic_monitor_weight),
+                    settingName = stringResource(id = R.string.health_connect),
+                    settingDesc = when {
+                        !healthConnectState.isAvailable -> {
+                            stringResource(id = R.string.health_connect_unavailable_desc)
+                        }
+                        healthConnectState.isExporting -> {
+                            stringResource(id = R.string.health_connect_exporting_desc)
+                        }
+                        healthConnectState.exportedRecords != null -> {
+                            stringResource(
+                                id = R.string.health_connect_exported_desc,
+                                healthConnectState.exportedRecords
+                            )
+                        }
+                        healthConnectState.hasPermissions -> {
+                            stringResource(id = R.string.health_connect_export_desc)
+                        }
+                        else -> {
+                            stringResource(id = R.string.health_connect_permissions_desc)
+                        }
+                    }
+                )
+            }
+
             item {
                 SettingItem(
                     isChecked = isWorkoutHeaderSticky,
@@ -268,12 +321,14 @@ private fun SettingItem(
     icon: Painter,
     settingName: String,
     settingDesc: String,
+    enabled: Boolean = true,
     isChecked: Boolean? = null
 ) {
     val haptic = LocalHapticFeedback.current
 
     Button(
         modifier = Modifier.animateContentSize(),
+        enabled = enabled,
         onClick = {
             haptic.performHapticFeedback(
                 hapticFeedbackType = isChecked?.let {
@@ -316,6 +371,7 @@ private fun SettingItem(
         isChecked?.let {
             Switch(
                 checked = it,
+                enabled = enabled,
                 onCheckedChange = null
             )
         }
@@ -345,6 +401,7 @@ fun SettingsScreenPreview() {
             restTimerSoundOn = restTimerSoundOn,
             updatePreferences = {},
             isSupporter = Random.nextBoolean(),
+            healthConnectState = HealthConnectState(isAvailable = true),
             isWorkoutHeaderSticky = isWorkoutHeaderSticky,
             useScrollWheelForInput = useScrollWheelForInput,
             dismissScrollWheelInputAutomatically = Random.nextBoolean(),
@@ -353,6 +410,7 @@ fun SettingsScreenPreview() {
             onRestTimerSoundOnChange = { restTimerSoundOn = it },
             onIsWorkoutHeaderStickyChange = { isWorkoutHeaderSticky = it },
             onUseScrollWheelForInputChange = { useScrollWheelForInput = it },
+            onHealthConnectClick = {},
             onDismissScrollWhellInputAutomaticallyChange = {}
         )
     }

--- a/app/src/main/java/org/librefit/ui/screens/settings/SettingsScreenViewModel.kt
+++ b/app/src/main/java/org/librefit/ui/screens/settings/SettingsScreenViewModel.kt
@@ -17,18 +17,23 @@ import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
+import org.librefit.db.repository.MeasurementRepository
 import org.librefit.db.repository.UserPreferencesRepository
 import org.librefit.enums.userPreferences.DialogPreference
 import org.librefit.enums.userPreferences.Language
 import org.librefit.enums.userPreferences.ThemeMode
+import org.librefit.health.HealthConnectRepository
 import javax.inject.Inject
 
 @HiltViewModel
 class SettingsScreenViewModel @Inject constructor(
-    private val userPreferences: UserPreferencesRepository
+    private val userPreferences: UserPreferencesRepository,
+    private val measurementRepository: MeasurementRepository,
+    private val healthConnectRepository: HealthConnectRepository
 ) : ViewModel() {
     val themeMode = userPreferences.themeMode
     val materialMode = userPreferences.materialMode
@@ -39,6 +44,14 @@ class SettingsScreenViewModel @Inject constructor(
     val isWorkoutHeaderSticky = userPreferences.isWorkoutHeaderSticky
     val useScrollWheelForInput = userPreferences.useScrollWheelForInput
     val dismissScrollWheelInputAutomatically = userPreferences.dismissScrollWheelInputAutomatically
+    val healthConnectPermissions = healthConnectRepository.writePermissions
+
+    private val _healthConnectState = MutableStateFlow(HealthConnectState())
+    val healthConnectState = _healthConnectState.asStateFlow()
+
+    init {
+        refreshHealthConnectState()
+    }
 
     fun saveThemeMode(mode: ThemeMode) {
         viewModelScope.launch { userPreferences.saveThemeMode(mode) }
@@ -71,6 +84,53 @@ class SettingsScreenViewModel @Inject constructor(
     fun saveDismissScrollWheelInputAutomatically(dismissAutomatically: Boolean) {
         viewModelScope.launch {
             userPreferences.saveDismissScrollWheelInputAutomatically(dismissAutomatically)
+        }
+    }
+
+    fun refreshHealthConnectState() {
+        viewModelScope.launch {
+            val isAvailable = healthConnectRepository.isAvailable()
+            val hasPermissions = isAvailable && healthConnectRepository.hasWritePermissions()
+
+            _healthConnectState.update {
+                it.copy(
+                    isAvailable = isAvailable,
+                    hasPermissions = hasPermissions,
+                    isExporting = false
+                )
+            }
+        }
+    }
+
+    fun updateHealthConnectPermissions(grantedPermissions: Set<String>) {
+        _healthConnectState.update {
+            it.copy(hasPermissions = grantedPermissions.containsAll(healthConnectPermissions))
+        }
+    }
+
+    fun exportMeasurementsToHealthConnect() {
+        viewModelScope.launch {
+            _healthConnectState.update { it.copy(isExporting = true, exportedRecords = null) }
+
+            runCatching {
+                healthConnectRepository.exportMeasurements(measurementRepository.measurements.first())
+            }.onSuccess { exportedRecords ->
+                _healthConnectState.update {
+                    it.copy(
+                        isExporting = false,
+                        hasPermissions = true,
+                        exportedRecords = exportedRecords
+                    )
+                }
+            }.onFailure {
+                _healthConnectState.update {
+                    it.copy(
+                        isExporting = false,
+                        hasPermissions = false,
+                        exportedRecords = null
+                    )
+                }
+            }
         }
     }
 
@@ -109,3 +169,10 @@ class SettingsScreenViewModel @Inject constructor(
         }
     }
 }
+
+data class HealthConnectState(
+    val isAvailable: Boolean = false,
+    val hasPermissions: Boolean = false,
+    val isExporting: Boolean = false,
+    val exportedRecords: Int? = null
+)

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -266,6 +266,7 @@
     <string name="privacy_notice_summary">LibreFit provides **maximum privacy** as it **cannot access the Internet**. In addition, all permissions are **optional** and do not allow data collection.</string>
     <string name="privacy_notice_optional_perm">Optional permissions</string>
     <string name="privacy_notice_notification_perm">**Notifications**: This permission allows the app to send notifications about your ongoing workout sessions and alerts when rest periods are over.</string>
+    <string name="privacy_notice_health_connect_perm">**Health Connect**: This permission allows the app to write body weight and body fat measurements to Health Connect only when you start the export from settings.</string>
     <string name="privacy_notice_default_perm">Permission granted by default</string>
     <string name="privacy_notice_foreground_perm">**Foreground Service**: This permission is automatically granted when LibreFit is installed and this allows it to run in the foreground during a workout.</string>
 
@@ -294,6 +295,13 @@
     <string name="screen_on_desc">Screen stays on during workout</string>
     <string name="screen_off_desc">Screen does not stay on during workout</string>
     <string name="settings_general">General</string>
+    <string name="integrations">Integrations</string>
+    <string name="health_connect">Health Connect</string>
+    <string name="health_connect_permissions_desc">Allow LibreFit to write body weight and body fat.</string>
+    <string name="health_connect_export_desc">Export body measurements to Health Connect.</string>
+    <string name="health_connect_exporting_desc">Exporting body measurements.</string>
+    <string name="health_connect_exported_desc">Exported %1$d measurement records.</string>
+    <string name="health_connect_unavailable_desc">Health Connect is not available on this device.</string>
     <string name="rest_timer_sound">Rest timer sound</string>
     <string name="rest_timer_sound_on_desc">Play a sound when rest timer ends</string>
     <string name="rest_timer_sound_off_desc">Rest timer alerts will be silent</string>

--- a/app/src/test/java/org/librefit/ui/screens/settings/SettingsScreenViewModelTest.kt
+++ b/app/src/test/java/org/librefit/ui/screens/settings/SettingsScreenViewModelTest.kt
@@ -20,9 +20,12 @@ import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
 import org.librefit.MainDispatcherRule
+import org.librefit.db.entity.Measurement
+import org.librefit.db.repository.MeasurementRepository
 import org.librefit.db.repository.UserPreferencesRepository
 import org.librefit.enums.userPreferences.Language
 import org.librefit.enums.userPreferences.ThemeMode
+import org.librefit.health.HealthConnectRepository
 
 @OptIn(ExperimentalCoroutinesApi::class)
 class SettingsScreenViewModelTest {
@@ -32,6 +35,8 @@ class SettingsScreenViewModelTest {
 
     // The mock repository
     private lateinit var userPreferencesRepository: UserPreferencesRepository
+    private lateinit var measurementRepository: MeasurementRepository
+    private lateinit var healthConnectRepository: HealthConnectRepository
 
     // The class under test
     private lateinit var viewModel: SettingsScreenViewModel
@@ -46,11 +51,14 @@ class SettingsScreenViewModelTest {
     private lateinit var isWorkoutHeaderSticky: MutableStateFlow<Boolean>
     private lateinit var useScrollWheelForInput: MutableStateFlow<Boolean>
     private lateinit var dismissScrollWheelAutomatically: MutableStateFlow<Boolean>
+    private lateinit var measurements: MutableStateFlow<List<Measurement>>
 
     @Before
     fun setUp() {
         // Arrange: Create a mock for the repository
         userPreferencesRepository = mockk()
+        measurementRepository = mockk()
+        healthConnectRepository = mockk()
         language = MutableStateFlow(Language.SYSTEM)
         themeMode = MutableStateFlow(ThemeMode.SYSTEM)
         keepScreenOn = MutableStateFlow(true)
@@ -60,6 +68,7 @@ class SettingsScreenViewModelTest {
         isWorkoutHeaderSticky = MutableStateFlow(true)
         useScrollWheelForInput = MutableStateFlow(true)
         dismissScrollWheelAutomatically = MutableStateFlow(false)
+        measurements = MutableStateFlow(emptyList())
 
         // Arrange: Tell the mock what to return when these are accessed
         every { userPreferencesRepository.language } returns language
@@ -71,6 +80,11 @@ class SettingsScreenViewModelTest {
         every { userPreferencesRepository.isWorkoutHeaderSticky } returns isWorkoutHeaderSticky
         every { userPreferencesRepository.useScrollWheelForInput } returns useScrollWheelForInput
         every { userPreferencesRepository.dismissScrollWheelInputAutomatically } returns dismissScrollWheelAutomatically
+        every { measurementRepository.measurements } returns measurements
+        every { healthConnectRepository.writePermissions } returns emptySet()
+        every { healthConnectRepository.isAvailable() } returns false
+        coEvery { healthConnectRepository.hasWritePermissions() } returns false
+        coEvery { healthConnectRepository.exportMeasurements(any()) } returns 0
 
         coEvery { userPreferencesRepository.saveLanguage(any()) } answers {
             language.value = Language.entries.find { it.code == firstArg() }!!
@@ -101,7 +115,11 @@ class SettingsScreenViewModelTest {
         }
 
         // Arrange: Create the ViewModel instance with the mock repository
-        viewModel = SettingsScreenViewModel(userPreferencesRepository)
+        viewModel = SettingsScreenViewModel(
+            userPreferencesRepository,
+            measurementRepository,
+            healthConnectRepository
+        )
     }
 
     @Test

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -14,6 +14,7 @@ coreSplashscreen = "1.2.0"
 composeM3 = "3.1.0"
 hiltAndroid = "2.59.2"
 hiltNavigationCompose = "1.3.0"
+healthConnect = "1.1.0"
 aboutLibraries = "14.2.0"
 aboutlibrariesComposeM3 = "14.2.0"
 kotlinxCoroutinesTest = "1.11.0"
@@ -55,6 +56,7 @@ compose-m3 = { group = "com.patrykandpatrick.vico", name = "compose-m3", version
 hilt-android = { group = "com.google.dagger", name = "hilt-android", version.ref = "hiltAndroid" }
 hilt-android-compiler = { group = "com.google.dagger", name = "hilt-android-compiler", version.ref = "hiltAndroid" }
 androidx-hilt-navigation-compose = { group = "androidx.hilt", name = "hilt-navigation-compose", version.ref = "hiltNavigationCompose" }
+androidx-health-connect = { group = "androidx.health.connect", name = "connect-client", version.ref = "healthConnect" }
 aboutlibraries-compose-m3 = { group = "com.mikepenz", name = "aboutlibraries-compose-m3", version.ref = "aboutlibrariesComposeM3" }
 kotlinx-coroutines-test = { group = "org.jetbrains.kotlinx", name = "kotlinx-coroutines-test", version.ref = "kotlinxCoroutinesTest" }
 androidx-truth = { group = "androidx.test.ext", name = "truth", version.ref = "truth" }


### PR DESCRIPTION
## Summary
- add an initial Health Connect integration for exporting LibreFit body measurements
- request only write access for body weight and body fat
- expose the export as an explicit Settings action instead of background sync
- update the Health Connect permission rationale on the privacy screen

## Scope
This is intended as a small first slice for #104. It does not import Health Connect records yet and does not export workouts/exercises yet, because those mappings need follow-up discussion.

## Testing
- `GRADLE_USER_HOME=E:\Documents\LibreFit\.gradle-user ./gradlew.bat --no-daemon :app:compileDebugKotlin :app:testDebugUnitTest`